### PR TITLE
allow enabling pytest-cov without overriding coverage --source

### DIFF
--- a/pytest_cov.py
+++ b/pytest_cov.py
@@ -14,7 +14,7 @@ def pytest_addoption(parser):
     group = parser.getgroup('coverage reporting with distributed testing '
                             'support')
     group.addoption('--cov', action='append', default=[], metavar='path',
-                    dest='cov_source',
+                    dest='cov_source', nargs='?', const=True,
                     help='measure coverage for filesystem path '
                     '(multi-allowed)')
     group.addoption('--cov-report', action='append', default=[],
@@ -36,6 +36,8 @@ def pytest_addoption(parser):
 def pytest_load_initial_conftests(early_config, parser, args):
     ns = parser.parse_known_args(args)
     if ns.cov_source:
+        while True in ns.cov_source:
+            ns.cov_source.remove(True)
         plugin = CovPlugin(ns, early_config.pluginmanager)
         early_config.pluginmanager.register(plugin, '_cov')
 

--- a/test_pytest_cov.py
+++ b/test_pytest_cov.py
@@ -107,6 +107,22 @@ def test_central(testdir):
     assert result.ret == 0
 
 
+def test_central_nonspecific(testdir):
+    script = testdir.makepyfile(SCRIPT)
+
+    result = testdir.runpytest('-v',
+                               '--cov',
+                               '--cov-report=term-missing',
+                               script)
+
+    result.stdout.fnmatch_lines([
+        '*- coverage: platform *, python * -*',
+        'test_central_nonspecific * %s *' % SCRIPT_RESULT,
+        '*10 passed*'
+        ])
+    assert result.ret == 0
+
+
 def test_no_cov_on_fail(testdir):
     script = testdir.makepyfile(SCRIPT_FAIL)
 


### PR DESCRIPTION
The goal is to allow source to be specified in .coveragerc, as it is under plain-old (non pytest) coverage.
