### PR TITLE
Enable coveragerc

### DIFF
--- a/test_pytest_cov.py
+++ b/test_pytest_cov.py
@@ -24,6 +24,11 @@ def test_foo():
         assert False
 '''
 
+COVERAGERC_SOURCE = '''\
+[run]
+source = .
+'''
+
 SCRIPT_CHILD = '''
 import sys
 
@@ -104,6 +109,47 @@ def test_central(testdir):
         'test_central * %s *' % SCRIPT_RESULT,
         '*10 passed*'
         ])
+    assert result.ret == 0
+
+
+def test_central_nonspecific(testdir):
+    script = testdir.makepyfile(SCRIPT)
+
+    result = testdir.runpytest('-v',
+                               '--cov-enabled',
+                               '--cov-report=term-missing',
+                               script)
+
+    result.stdout.fnmatch_lines([
+        '*- coverage: platform *, python * -*',
+        'test_central_nonspecific * %s *' % SCRIPT_RESULT,
+        '*10 passed*'
+        ])
+
+    # multi-module coverage report
+    assert result.stdout.lines[-3].startswith('TOTAL ')
+
+    assert result.ret == 0
+
+
+def test_central_coveragerc(testdir):
+    script = testdir.makepyfile(SCRIPT)
+    testdir.tmpdir.join('.coveragerc').write(COVERAGERC_SOURCE)
+
+    result = testdir.runpytest('-v',
+                               '--cov-enabled',
+                               '--cov-report=term-missing',
+                               script)
+
+    result.stdout.fnmatch_lines([
+        '*- coverage: platform *, python * -*',
+        'test_central_coveragerc * %s *' % SCRIPT_RESULT,
+        '*10 passed*',
+        ])
+
+    # single-module coverage report
+    assert result.stdout.lines[-3].startswith('test_central_coveragerc ')
+
     assert result.ret == 0
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,8 @@ usedevelop = True
 setenv =
     PYTHONHASHSEED = random
 deps =
+    #FIXME: delete next line after merging https://github.com/schlamar/cov-core/pull/5
+    git+git://github.com/bukzor/cov-core.git
     pytest
     pytest-xdist
     virtualenv


### PR DESCRIPTION
The essential idea is that there should be a way to enable pytest-cov without overriding the source setting in .coveragerc.

The new test requires the pull request to cov-core here: https://github.com/schlamar/cov-core/pull/5

This is my second implementation. You can compare to the first here:
Find the diff here: https://github.com/bukzor/pytest-cov/commit/ebfcf418ec776b3fff165be92c9fb9d674790593
