### PR TITLE
naming convention in coverage changed at version 4.0a0

### DIFF
--- a/test_pytest_cov.py
+++ b/test_pytest_cov.py
@@ -58,7 +58,7 @@ SCRIPT_FUNCARG = '''
 import coverage
 
 def test_foo(cov):
-    assert isinstance(cov, coverage.control.coverage)
+    assert isinstance(cov, coverage.coverage)
 '''
 
 SCRIPT_FUNCARG_NOT_ACTIVE = '''


### PR DESCRIPTION
This test started failing today because the coverage class changed to pep8 Coverage class.

According to ned, the public interface for the coverage class is coverage.coverage.
