### PR TITLE
enable coveragerc [run]source (alternate implementation)

### DIFF
--- a/pytest_cov.py
+++ b/pytest_cov.py
@@ -14,7 +14,7 @@ def pytest_addoption(parser):
     group = parser.getgroup('coverage reporting with distributed testing '
                             'support')
     group.addoption('--cov', action='append', default=[], metavar='path',
-                    dest='cov_source',
+                    dest='cov_source', nargs='?', const=True,
                     help='measure coverage for filesystem path '
                     '(multi-allowed)')
     group.addoption('--cov-report', action='append', default=[],
@@ -90,8 +90,14 @@ class CovPlugin(object):
 
             config = Config()
 
+        source = list(self.options.cov_source)
+        while True in source:
+            source.remove(True)
+        if not source:
+            source = None
+
         self.cov_controller = controller_cls(
-            self.options.cov_source,
+            source,
             self.options.cov_report or ['term'],
             self.options.cov_config,
             config,

--- a/test_pytest_cov.py
+++ b/test_pytest_cov.py
@@ -25,6 +25,11 @@ def test_foo():
         assert False
 '''
 
+COVERAGERC_SOURCE = '''\
+[run]
+source = .
+'''
+
 SCRIPT_CHILD = '''
 import sys
 
@@ -105,6 +110,47 @@ def test_central(testdir):
         'test_central * %s *' % SCRIPT_RESULT,
         '*10 passed*'
         ])
+    assert result.ret == 0
+
+
+def test_central_nonspecific(testdir):
+    script = testdir.makepyfile(SCRIPT)
+
+    result = testdir.runpytest('-v',
+                               '--cov',
+                               '--cov-report=term-missing',
+                               script)
+
+    result.stdout.fnmatch_lines([
+        '*- coverage: platform *, python * -*',
+        'test_central_nonspecific * %s *' % SCRIPT_RESULT,
+        '*10 passed*'
+        ])
+
+    # multi-module coverage report
+    assert result.stdout.lines[-3].startswith('TOTAL ')
+
+    assert result.ret == 0
+
+
+def test_central_coveragerc(testdir):
+    script = testdir.makepyfile(SCRIPT)
+    testdir.tmpdir.join('.coveragerc').write(COVERAGERC_SOURCE)
+
+    result = testdir.runpytest('-v',
+                               '--cov',
+                               '--cov-report=term-missing',
+                               script)
+
+    result.stdout.fnmatch_lines([
+        '*- coverage: platform *, python * -*',
+        'test_central_coveragerc * %s *' % SCRIPT_RESULT,
+        '*10 passed*',
+        ])
+
+    # single-module coverage report
+    assert not result.stdout.lines[-3].startswith('test_central_coveragerc\t')
+
     assert result.ret == 0
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,8 @@ usedevelop = True
 setenv =
     PYTHONHASHSEED = random
 deps =
+    #FIXME: delete next line after merging https://github.com/schlamar/cov-core/pull/6
+    git+git://github.com/bukzor/cov-core.git@enable-coveragerc
     pytest
     pytest-xdist
     virtualenv


### PR DESCRIPTION
alternative to #21

This make it such that we can pass --cov without a value and it does the Right Thing.
