### PR TITLE
Coverage 4.0b2 support

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,4 @@
+[bumpversion]
+current_version = 2.0.0
+commit = True
+tag = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,3 @@
-[bumpversion]
-current_version = 2.0.0
-commit = True
-tag = True
-
 [bdist_wheel]
 universal = 1
 
@@ -20,29 +15,29 @@ exclude = tests/*,*/migrations/*,*/south_migrations/*
 [bumpversion:file:src/pytest_cov/__init__.py]
 
 [pytest]
-norecursedirs = 
-	.git
-	.tox
-	.env
-	dist
-	build
-	south_migrations
-	migrations
-	example
-python_files = 
-	test_*.py
-	*_test.py
-	tests.py
-addopts = 
-	-rxEfs
-	--strict
-	--ignore=docs/conf.py
-	--ignore=setup.py
-	--ignore=src
-	--ignore=ci
-	--doctest-modules
-	--doctest-glob=\*.rst
-	--tb=short
+norecursedirs =
+    .git
+    .tox
+    .env
+    dist
+    build
+    south_migrations
+    migrations
+    example
+python_files =
+    test_*.py
+    *_test.py
+    tests.py
+addopts =
+    -rxEfs
+    --strict
+    --ignore=docs/conf.py
+    --ignore=setup.py
+    --ignore=src
+    --ignore=ci
+    --doctest-modules
+    --doctest-glob=\*.rst
+    --tb=short
 
 [isort]
 force_single_line = True

--- a/src/pytest_cov/embed.py
+++ b/src/pytest_cov/embed.py
@@ -56,7 +56,7 @@ def init():
                                 data_suffix=True,
                                 config_file=cov_config,
                                 auto_data=True)
-        cov.erase()
+        cov.load()
         cov.start()
         cov._warn_no_data = False
         cov._warn_unimported_source = False

--- a/src/pytest_cov/engine.py
+++ b/src/pytest_cov/engine.py
@@ -5,9 +5,9 @@ import random
 import socket
 import sys
 try:
-    from io import StringIO
-except ImportError:
     from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 import coverage
 

--- a/src/pytest_cov/engine.py
+++ b/src/pytest_cov/engine.py
@@ -170,8 +170,12 @@ class DistMaster(CovController):
                                     data_suffix=data_suffix,
                                     config_file=self.cov_config)
             cov.start()
-            cov.data.lines = node.slaveoutput['cov_slave_lines']
-            cov.data.arcs = node.slaveoutput['cov_slave_arcs']
+            if hasattr(self.cov.data, '_lines'):  # for coverage 4.0b1 or older
+                cov.data._lines = node.slaveoutput['cov_slave_lines']
+                cov.data._arcs = node.slaveoutput['cov_slave_arcs']
+            else:
+                cov.data.lines = node.slaveoutput['cov_slave_lines']
+                cov.data.arcs = node.slaveoutput['cov_slave_arcs']
             cov.stop()
             cov.save()
             path = node.slaveoutput['cov_slave_path']
@@ -241,8 +245,12 @@ class DistSlave(CovController):
             # Send all the data to the master over the channel.
             self.config.slaveoutput['cov_slave_path'] = self.topdir
             self.config.slaveoutput['cov_slave_node_id'] = self.nodeid
-            self.config.slaveoutput['cov_slave_lines'] = self.cov.data.lines
-            self.config.slaveoutput['cov_slave_arcs'] = self.cov.data.arcs
+            if hasattr(self.cov.data, '_lines'):  # for coverage 4.0b1 or older
+                self.config.slaveoutput['cov_slave_lines'] = self.cov.data._lines
+                self.config.slaveoutput['cov_slave_arcs'] = self.cov.data._arcs
+            else:
+                self.config.slaveoutput['cov_slave_lines'] = self.cov.data.lines
+                self.config.slaveoutput['cov_slave_arcs'] = self.cov.data.arcs
 
     def summary(self, stream):
         """Only the master reports so do nothing."""

--- a/src/pytest_cov/engine.py
+++ b/src/pytest_cov/engine.py
@@ -174,7 +174,7 @@ class DistMaster(CovController):
                                     data_suffix=data_suffix,
                                     config_file=self.cov_config)
             cov.start()
-            if hasattr(self.cov.data, 'read_fileobj'):  # for coverage 4.0b1 or older
+            if hasattr(self.cov.data, 'read_fileobj'):  # for coverage 4.0
                 cov.data.read_fileobj(StringIO(node.slaveoutput['cov_slave_data']))
             else:
                 cov.data.lines, cov.data.arcs = node.slaveoutput['cov_slave_data']

--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -2,6 +2,7 @@
 import os
 
 import pytest
+from coverage.misc import CoverageException
 
 from . import embed
 from . import engine
@@ -160,7 +161,11 @@ class CovPlugin(object):
         if self.cov_controller is None:
             return
         if not (self.failed and self.options.no_cov_on_fail):
-            total = self.cov_controller.summary(terminalreporter.writer)
+            try:
+                total = self.cov_controller.summary(terminalreporter.writer)
+            except CoverageException as exc:
+                terminalreporter.writer.write('Failed to generate report: %s\n' % exc)
+                total = 0
             assert total is not None, 'Test coverage should never be `None`'
             cov_fail_under = self.options.cov_fail_under
             if cov_fail_under is not None and total < cov_fail_under:

--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -287,6 +287,7 @@ def test_dist_collocated(testdir):
                                '--cov-report=term-missing',
                                '--dist=load',
                                '--tx=2*popen',
+                               '--max-slave-restart=0',
                                script)
 
     result.stdout.fnmatch_lines([
@@ -309,6 +310,7 @@ def test_dist_not_collocated(testdir):
                                '--tx=popen//chdir=%s' % dir1,
                                '--tx=popen//chdir=%s' % dir2,
                                '--rsyncdir=%s' % script.basename,
+                               '--max-slave-restart=0', '-s',
                                script)
 
     result.stdout.fnmatch_lines([
@@ -371,6 +373,7 @@ def test_dist_subprocess_collocated(testdir):
                                '--cov-report=term-missing',
                                '--dist=load',
                                '--tx=2*popen',
+                               '--max-slave-restart=0',
                                parent_script)
 
     result.stdout.fnmatch_lines([
@@ -398,6 +401,7 @@ def test_dist_subprocess_not_collocated(testdir, tmpdir):
                                '--tx=popen//chdir=%s' % dir2,
                                '--rsyncdir=%s' % child_script,
                                '--rsyncdir=%s' % parent_script,
+                               '--max-slave-restart=0',
                                parent_script)
 
     result.stdout.fnmatch_lines([
@@ -440,6 +444,7 @@ def test_dist_missing_data(testdir):
                                '--cov-report=term-missing',
                                '--dist=load',
                                '--tx=popen//python=%s' % exe,
+                               '--max-slave-restart=0',
                                script)
 
     result.stdout.fnmatch_lines([
@@ -557,6 +562,7 @@ def test_cover_conftest_dist(testdir):
                                '--cov-report=term-missing',
                                '--dist=load',
                                '--tx=2*popen',
+                               '--max-slave-restart=0',
                                script)
     assert result.ret == 0
     result.stdout.fnmatch_lines([CONF_RESULT])
@@ -604,6 +610,7 @@ def test_coveragerc_dist(testdir):
                                '--cov=%s' % script.dirpath(),
                                '--cov-report=term-missing',
                                '-n', '2',
+                               '--max-slave-restart=0',
                                script)
     assert result.ret == 0
     result.stdout.fnmatch_lines(
@@ -728,6 +735,7 @@ data_file = %s
     result = testdir.runpytest('-v',
                                '--cov=%s' % script.dirpath(),
                                '-n', '1',
+                               '--max-slave-restart=0',
                                script)
     assert result.ret == 0
     assert glob.glob(str(testdir.tmpdir.join('some/special/place/coverage-data*')))

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,8 @@ deps =
     pytest==2.7.2
     pytest-capturelog
     37: coverage==3.7.1
-    40: coverage==4.0b1
+    40: https://bitbucket.org/ned/coveragepy/get/74e2f7c366a2.zip
+    #coverage==4.0b1
     virtualenv
     pytest-xdist==1.13
     pytest-cache==1.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -23,8 +23,7 @@ deps =
     pytest==2.7.2
     pytest-capturelog
     37: coverage==3.7.1
-    40: https://bitbucket.org/ned/coveragepy/get/c0ccebb98c23.zip
-    #coverage==4.0b1
+    40: coverage==4.0b2
     virtualenv
     pytest-xdist==1.13
     pytest-cache==1.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ setenv =
     SPELLCHECK=1
 commands =
     sphinx-build -b spelling docs dist/docs
-usedevelop = true
+skip_install = true
 deps =
     -r{toxinidir}/docs/requirements.txt
     sphinxcontrib-spelling
@@ -64,7 +64,7 @@ deps =
     flake8
     readme
     pygments
-usedevelop = true
+skip_install = true
 commands =
     python setup.py check --strict --metadata --restructuredtext
     check-manifest {toxinidir}

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ deps =
     pytest==2.7.2
     pytest-capturelog
     37: coverage==3.7.1
-    40: https://bitbucket.org/ned/coveragepy/get/74e2f7c366a2.zip
+    40: https://bitbucket.org/ned/coveragepy/get/c0ccebb98c23.zip
     #coverage==4.0b1
     virtualenv
     pytest-xdist==1.13


### PR DESCRIPTION
These changes need a version later than 4.0b1 (the b1 release has this issue https://bitbucket.org/ned/coveragepy/issues/399/coverageexception-cant-combine-line-data). cc @The-Compiler 