### PR TITLE
Skip xdist tests if no xdist installed

### DIFF
--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -100,6 +100,12 @@ def test_run_target():
     p.join()
 '''
 
+try:
+    import xdist
+    HAS_XDIST = True
+except:
+    HAS_XDIST = False
+
 SCRIPT_FAIL = '''
 def test_fail():
     assert False
@@ -111,7 +117,11 @@ SCRIPT2_RESULT = '3 * 100%'
 CHILD_SCRIPT_RESULT = '6 * 100%'
 PARENT_SCRIPT_RESULT = '8 * 100%'
 
-xdist = pytest.mark.parametrize('opts', ['', '-n 1'], ids=['nodist', 'xdist'])
+try:
+    import xdist
+    xdist = pytest.mark.parametrize('opts', ['', '-n 1'], ids=['nodist', 'xdist'])
+except:
+    xdist = pytest.mark.parametrize('opts', [''], ids=['nodist'])
 
 
 def test_central(testdir):
@@ -251,6 +261,7 @@ show_missing = true
     assert result.ret == 0
 
 
+@pytest.mark.skipif("not HAS_XDIST")
 def test_no_cov_on_fail(testdir):
     script = testdir.makepyfile(SCRIPT_FAIL)
 
@@ -264,6 +275,7 @@ def test_no_cov_on_fail(testdir):
     result.stdout.fnmatch_lines(['*1 failed*'])
 
 
+@pytest.mark.skipif("not HAS_XDIST")
 def test_dist_combine_racecondition(testdir):
     script = testdir.makepyfile("""
 import pytest
@@ -290,6 +302,7 @@ def test_foo(foo):
     assert result.ret == 0
 
 
+@pytest.mark.skipif("not HAS_XDIST")
 def test_dist_collocated(testdir):
     script = testdir.makepyfile(SCRIPT)
 
@@ -309,6 +322,7 @@ def test_dist_collocated(testdir):
     assert result.ret == 0
 
 
+@pytest.mark.skipif("not HAS_XDIST")
 def test_dist_not_collocated(testdir):
     script = testdir.makepyfile(SCRIPT)
     dir1 = testdir.mkdir('dir1')
@@ -374,6 +388,7 @@ omit =
     assert result.ret == 0
 
 
+@pytest.mark.skipif("not HAS_XDIST")
 def test_dist_subprocess_collocated(testdir):
     scripts = testdir.makepyfile(parent_script=SCRIPT_PARENT,
                                  child_script=SCRIPT_CHILD)
@@ -395,6 +410,7 @@ def test_dist_subprocess_collocated(testdir):
     assert result.ret == 0
 
 
+@pytest.mark.skipif("not HAS_XDIST")
 def test_dist_subprocess_not_collocated(testdir, tmpdir):
     scripts = testdir.makepyfile(parent_script=SCRIPT_PARENT,
                                  child_script=SCRIPT_CHILD)
@@ -440,6 +456,7 @@ def test_empty_report(testdir):
     assert not matching_lines
 
 
+@pytest.mark.skipif("not HAS_XDIST")
 def test_dist_missing_data(testdir):
     venv_path = os.path.join(str(testdir.tmpdir), 'venv')
     virtualenv.create_environment(venv_path)
@@ -546,6 +563,7 @@ def test_cover_conftest(testdir):
     result.stdout.fnmatch_lines([CONF_RESULT])
 
 
+@pytest.mark.skipif("not HAS_XDIST")
 def test_cover_looponfail(testdir, monkeypatch):
     testdir.makepyfile(mod=MODULE)
     testdir.makeconftest(CONFTEST)
@@ -564,6 +582,7 @@ def test_cover_looponfail(testdir, monkeypatch):
             )
 
 
+@pytest.mark.skipif("not HAS_XDIST")
 def test_cover_conftest_dist(testdir):
     testdir.makepyfile(mod=MODULE)
     testdir.makeconftest(CONFTEST)
@@ -613,6 +632,7 @@ def test_coveragerc(testdir):
     result.stdout.fnmatch_lines(['test_coveragerc* %s' % EXCLUDED_RESULT])
 
 
+@pytest.mark.skipif("not HAS_XDIST")
 def test_coveragerc_dist(testdir):
     testdir.makefile('', coveragerc=COVERAGERC)
     script = testdir.makepyfile(EXCLUDED_TEST)
@@ -659,7 +679,7 @@ def test_foo():
 SCRIPT_SIMPLE_RESULT = '4 * 100%'
 
 
-@pytest.mark.skipif('sys.platform == "win32"')
+@pytest.mark.skipif('sys.platform == "win32" or not HAS_XDIST')
 def test_dist_boxed(testdir):
     script = testdir.makepyfile(SCRIPT_SIMPLE)
 
@@ -735,6 +755,7 @@ data_file = %s
     assert glob.glob(str(testdir.tmpdir.join('some/special/place/coverage-data*')))
 
 
+@pytest.mark.skipif("not HAS_XDIST")
 def test_external_data_file_xdist(testdir):
     script = testdir.makepyfile(SCRIPT)
     testdir.tmpdir.join('.coveragerc').write("""


### PR DESCRIPTION
Fedora does not currently have pytest-xdist, so we need to skip running the tests that require xdist.
