### PR TITLE
Fix handling when tests change working directory.

### DIFF
--- a/src/pytest_cov/embed.py
+++ b/src/pytest_cov/embed.py
@@ -41,7 +41,8 @@ def init():
 
     cov_source = os.environ.get('COV_CORE_SOURCE')
     cov_config = os.environ.get('COV_CORE_CONFIG')
-    if cov_config:
+    cov_datafile = os.environ.get('COV_CORE_DATAFILE')
+    if cov_datafile:
         # Import what we need to activate coverage.
         import coverage
 
@@ -50,12 +51,17 @@ def init():
             cov_source = None
         else:
             cov_source = cov_source.split(os.pathsep)
+        if not cov_config:
+            cov_config = True
 
         # Activate coverage for this process.
-        cov = coverage.coverage(source=cov_source,
-                                data_suffix=True,
-                                config_file=cov_config,
-                                auto_data=True)
+        cov = coverage.coverage(
+            source=cov_source,
+            data_suffix=True,
+            config_file=cov_config,
+            auto_data=True,
+            data_file=cov_datafile
+        )
         cov.load()
         cov.start()
         cov._warn_no_data = False

--- a/src/pytest_cov/engine.py
+++ b/src/pytest_cov/engine.py
@@ -34,14 +34,21 @@ class CovController(object):
         if self.cov_source is None:
             os.environ['COV_CORE_SOURCE'] = ''
         else:
-            os.environ['COV_CORE_SOURCE'] = os.pathsep.join(self.cov_source)
-        os.environ['COV_CORE_CONFIG'] = self.cov_config
+            os.environ['COV_CORE_SOURCE'] = os.pathsep.join(
+                os.path.abspath(p) for p in self.cov_source)
+        config_file = os.path.abspath(self.cov_config)
+        if os.path.exists(config_file):
+            os.environ['COV_CORE_CONFIG'] = config_file
+        else:
+            os.environ['COV_CORE_CONFIG'] = ''
+        os.environ['COV_CORE_DATAFILE'] = os.path.abspath('.coverage')
 
     @staticmethod
     def unset_env():
         """Remove coverage info from env."""
         os.environ.pop('COV_CORE_SOURCE', None)
         os.environ.pop('COV_CORE_CONFIG', None)
+        os.environ.pop('COV_CORE_DATAFILE', None)
 
     @staticmethod
     def get_node_desc(platform, version_info):


### PR DESCRIPTION
Use absolute paths for coverage config file and sources. Add a new internal variable "COV_CORE_DATAFILE" to workaround the misplacement of .coverage.foobar.123 files.

Because needs to be an absolute path COV_CORE_CONFIG we need to do some special things: coverage treats config_file='.coveragerc' as if it was config_file=True. We need to keep that behavior.

Closes #94. Closes #77.