### PR TITLE
Fix handling for --cov-report=annotate.

### DIFF
--- a/src/pytest_cov/engine.py
+++ b/src/pytest_cov/engine.py
@@ -91,7 +91,8 @@ class CovController(object):
 
         # Produce annotated source code report if wanted.
         if 'annotate' in self.cov_report:
-            total = self.cov.annotate(ignore_errors=True)
+            self.cov.annotate(ignore_errors=True)
+            total = self.cov.report(ignore_errors=True, file=StringIO())
             stream.write('Coverage annotated source written next to source\n')
 
         # Produce html report if wanted.

--- a/src/pytest_cov/engine.py
+++ b/src/pytest_cov/engine.py
@@ -92,6 +92,8 @@ class CovController(object):
         # Produce annotated source code report if wanted.
         if 'annotate' in self.cov_report:
             self.cov.annotate(ignore_errors=True)
+            # We need to call Coverage.report here, just to get the total
+            # Coverage.annotate don't return any total and we need it for --cov-fail-under.
             total = self.cov.report(ignore_errors=True, file=StringIO())
             stream.write('Coverage annotated source written next to source\n')
 

--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -154,6 +154,22 @@ def test_central(testdir):
     assert result.ret == 0
 
 
+def test_annotate(testdir):
+    script = testdir.makepyfile(SCRIPT)
+
+    result = testdir.runpytest('-v',
+                               '--cov=%s' % script.dirpath(),
+                               '--cov-report=annotate',
+                               script)
+
+    result.stdout.fnmatch_lines([
+        '*- coverage: platform *, python * -*',
+        'Coverage annotated source written next to source',
+        '*10 passed*',
+    ])
+    assert result.ret == 0
+
+
 def test_cov_min_100(testdir):
     script = testdir.makepyfile(SCRIPT)
 


### PR DESCRIPTION
Add workaround for missing percentage total return from Coverage.annotate.

Also add missing test for --cov-report=annotate.

Closes #92.