### PR TITLE
Add Python 3.5 to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -108,6 +108,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Utilities',


### PR DESCRIPTION
3.5 is missing from the badge at https://github.com/pytest-dev/pytest-cov/blob/master/README.rst but looks like you support it.