### PR TITLE
Dont absolutize source path

### DIFF
--- a/src/pytest_cov/engine.py
+++ b/src/pytest_cov/engine.py
@@ -35,8 +35,7 @@ class CovController(object):
         if self.cov_source is None:
             os.environ['COV_CORE_SOURCE'] = ''
         else:
-            os.environ['COV_CORE_SOURCE'] = os.pathsep.join(
-                os.path.abspath(p) for p in self.cov_source)
+            os.environ['COV_CORE_SOURCE'] = os.pathsep.join(self.cov_source)
         config_file = os.path.abspath(self.cov_config)
         if os.path.exists(config_file):
             os.environ['COV_CORE_CONFIG'] = config_file

--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -115,6 +115,7 @@ def test_foo(idx):
     subprocess.check_call([
         sys.executable,
         '-c', 'import sys; sys.argv = ["", str(%s)]; import child_script' % idx
+    ])
 
 # there is a issue in coverage.py with multiline statements at
 # end of file: https://bitbucket.org/ned/coveragepy/issue/293

--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -114,8 +114,7 @@ def test_foo(idx):
 
     subprocess.check_call([
         sys.executable,
-        '-m', 'child_script', str(idx)
-    ])
+        '-c', 'import sys; sys.argv = ["", str(%s)]; import child_script' % idx
 
 # there is a issue in coverage.py with multiline statements at
 # end of file: https://bitbucket.org/ned/coveragepy/issue/293


### PR DESCRIPTION
This fixes lack of coverage measurements when covered module is out of CWD and `--cov=module` was used.

(only affects suprocess measurements)