### PR TITLE
Specify file output

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -13,3 +13,4 @@ Authors
 * Ionel Cristian Mărieș - http://blog.ionelmc.ro
 * Christian Ledermann - https://github.com/cleder
 * Alec Nikolas Reiter - https://github.com/justanr
+* Patrick Lannigan - https://github.com/unholysampler

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+2.2.2 (tba)
+------------------
+
+* Add support for specifying output location for html, xml, and annotate report.
+
 2.2.1 (2016-01-30)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -231,6 +231,15 @@ These three report options output to files without showing anything on the termi
             --cov-report annotate
             --cov=myproj tests/
 
+The output location for each of these reports can be specified. The output location for the XML
+report is a file. Where as the output location for the HTML and annotated source code reports are
+directories::
+
+    py.test --cov-report html:cov_html
+            --cov-report xml:cov.xml
+            --cov-report annotate:cov_annotate
+            --cov=myproj tests/
+
 The final report option can also suppress printing to the terminal::
 
     py.test --cov-report= --cov=myproj tests/

--- a/src/pytest_cov/engine.py
+++ b/src/pytest_cov/engine.py
@@ -92,20 +92,24 @@ class CovController(object):
 
         # Produce annotated source code report if wanted.
         if 'annotate' in self.cov_report:
-            self.cov.annotate(ignore_errors=True)
+            annotate_dir = self.cov_report['annotate']
+            self.cov.annotate(ignore_errors=True, directory=annotate_dir)
             # We need to call Coverage.report here, just to get the total
             # Coverage.annotate don't return any total and we need it for --cov-fail-under.
             total = self.cov.report(ignore_errors=True, file=StringIO())
-            stream.write('Coverage annotated source written next to source\n')
+            if annotate_dir:
+                stream.write('Coverage annotated source written to dir %s\n' % annotate_dir)
+            else:
+                stream.write('Coverage annotated source written next to source\n')
 
         # Produce html report if wanted.
         if 'html' in self.cov_report:
-            total = self.cov.html_report(ignore_errors=True)
+            total = self.cov.html_report(ignore_errors=True, directory=self.cov_report['html'])
             stream.write('Coverage HTML written to dir %s\n' % self.cov.config.html_dir)
 
         # Produce xml report if wanted.
         if 'xml' in self.cov_report:
-            total = self.cov.xml_report(ignore_errors=True)
+            total = self.cov.xml_report(ignore_errors=True, outfile=self.cov_report['xml'])
             stream.write('Coverage XML written to file %s\n' % self.cov.config.xml_output)
 
         # Report on any failed slaves.

--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -235,7 +235,10 @@ def test_term_output_dir(testdir):
                                '--cov-report=term:' + DEST_DIR,
                                script)
 
+    # backport of argparse to py26 doesn't display ArgumentTypeError message
     result.stderr.fnmatch_lines([
+        '*argument --cov-report: *',
+    ] if tuple(sys.version_info[:2]) == (2, 6) else [
         '*argument --cov-report: output specifier not supported for: "term:%s"*' % DEST_DIR,
     ])
     assert result.ret != 0
@@ -249,7 +252,10 @@ def test_term_missing_output_dir(testdir):
                                '--cov-report=term-missing:' + DEST_DIR,
                                script)
 
+    # backport of argparse to py26 doesn't display ArgumentTypeError message
     result.stderr.fnmatch_lines([
+        '*argument --cov-report: *',
+    ] if tuple(sys.version_info[:2]) == (2, 6) else [
         '*argument --cov-report: output specifier not supported for: '
         '"term-missing:%s"*' % DEST_DIR,
     ])


### PR DESCRIPTION
Add support for specifying output location for html, xml, and annotate report. Fixes issue #97.