### PR TITLE
Add support for 'skip_covered' option in terminal report section

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -16,3 +16,4 @@ Authors
 * Patrick Lannigan - https://github.com/unholysampler
 * David Szotten - https://github.com/davidszotten
 * Michael Elovskikh - https://github.com/wronglink
+* Saurabh Kumar - https://github.com/theskumar

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,8 @@ Changelog
   Contributed by David Szotten in `PR#116 <https://github.com/pytest-dev/pytest-cov/pull/116>`_.
 * Fixed bug occurred when bare ``--cov`` parameter was used with xdist.
   Contributed by Michael Elovskikh in `PR#120 <https://github.com/pytest-dev/pytest-cov/pull/120>`_.
-
+* Add support for ``skip_covered`` and added ``--cov-report=term-skip-covered`` command
+  line options. Contributed by Saurabh Kumar in `PR#115 <https://github.com/pytest-dev/pytest-cov/pull/115>`_.
 
 2.2.1 (2016-01-30)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -223,6 +223,19 @@ The terminal report with line numbers::
     --------------------------------------------------
     TOTAL                  353     20    94%
 
+The terminal report with skip covered::
+
+    py.test --cov-report term-skip-covered --cov=myproj tests/
+
+    -------------------- coverage: platform linux2, python 2.6.4-final-0 ---------------------
+    Name                 Stmts   Miss  Cover
+    ----------------------------------------
+    myproj/myproj          257     13    94%
+    myproj/feature4286      94      7    92%
+    ----------------------------------------
+    TOTAL                  353     20    94%
+
+    1 files skipped due to complete coverage.
 
 These three report options output to files without showing anything on the terminal::
 

--- a/README.rst
+++ b/README.rst
@@ -225,7 +225,7 @@ The terminal report with line numbers::
 
 The terminal report with skip covered::
 
-    py.test --cov-report term-skip-covered --cov=myproj tests/
+    py.test --cov-report term:skip-covered --cov=myproj tests/
 
     -------------------- coverage: platform linux2, python 2.6.4-final-0 ---------------------
     Name                 Stmts   Miss  Cover
@@ -236,6 +236,8 @@ The terminal report with skip covered::
     TOTAL                  353     20    94%
 
     1 files skipped due to complete coverage.
+
+You can use ``skip-covered`` with ``term-missing`` as well. e.g. ``--cov-report term-missing:skip-covered``
 
 These three report options output to files without showing anything on the terminal::
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,7 @@ norecursedirs =
     .git
     .tox
     .env
+    venv
     dist
     build
     south_migrations

--- a/src/pytest_cov/engine.py
+++ b/src/pytest_cov/engine.py
@@ -83,9 +83,15 @@ class CovController(object):
                 self.sep(stream, ' ', '%s' % node_desc)
 
         # Produce terminal report if wanted.
-        if 'term' in self.cov_report or 'term-missing' in self.cov_report:
-            show_missing = ('term-missing' in self.cov_report) or None
-            total = self.cov.report(show_missing=show_missing, ignore_errors=True, file=stream)
+        if any(x in self.cov_report for x in ['term', 'term-missing', 'term-skip-covered']):
+            options = {
+                'show_missing': ('term-missing' in self.cov_report) or None,
+                'ignore_errors': True,
+                'file': stream,
+            }
+            if hasattr(coverage, 'version_info') and coverage.version_info[0] >= 4:
+                options.update({'skip_covered': ('term-skip-covered' in self.cov_report) or None})
+            total = self.cov.report(**options)
 
         # Produce annotated source code report if wanted.
         if 'annotate' in self.cov_report:

--- a/src/pytest_cov/engine.py
+++ b/src/pytest_cov/engine.py
@@ -90,9 +90,8 @@ class CovController(object):
                 'file': stream,
             }
             skip_covered = isinstance(self.cov_report, dict) and 'skip-covered' in self.cov_report.values()
-            if skip_covered:
-                if hasattr(coverage, 'version_info') and coverage.version_info[0] >= 4:
-                    options.update({'skip_covered': skip_covered or None})
+            if hasattr(coverage, 'version_info') and coverage.version_info[0] >= 4:
+                options.update({'skip_covered': skip_covered or None})
             total = self.cov.report(**options)
 
         # Produce annotated source code report if wanted.

--- a/src/pytest_cov/engine.py
+++ b/src/pytest_cov/engine.py
@@ -83,14 +83,16 @@ class CovController(object):
                 self.sep(stream, ' ', '%s' % node_desc)
 
         # Produce terminal report if wanted.
-        if any(x in self.cov_report for x in ['term', 'term-missing', 'term-skip-covered']):
+        if any(x in self.cov_report for x in ['term', 'term-missing']):
             options = {
                 'show_missing': ('term-missing' in self.cov_report) or None,
                 'ignore_errors': True,
                 'file': stream,
             }
-            if hasattr(coverage, 'version_info') and coverage.version_info[0] >= 4:
-                options.update({'skip_covered': ('term-skip-covered' in self.cov_report) or None})
+            skip_covered = isinstance(self.cov_report, dict) and 'skip-covered' in self.cov_report.values()
+            if skip_covered:
+                if hasattr(coverage, 'version_info') and coverage.version_info[0] >= 4:
+                    options.update({'skip_covered': skip_covered or None})
             total = self.cov.report(**options)
 
         # Produce annotated source code report if wanted.

--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -16,7 +16,8 @@ class CoverageError(Exception):
 
 def validate_report(arg):
     file_choices = ['annotate', 'html', 'xml']
-    term_choices = ['term', 'term-missing', 'term-skip-covered']
+    term_choices = ['term', 'term-missing']
+    term_modifier_choices = ['skip-covered']
     all_choices = term_choices + file_choices
     values = arg.split(":", 1)
     report_type = values[0]
@@ -26,6 +27,10 @@ def validate_report(arg):
 
     if len(values) == 1:
         return report_type, None
+
+    report_modifier = values[1]
+    if report_type in term_choices and report_modifier in term_modifier_choices:
+        return report_type, report_modifier
 
     if report_type not in file_choices:
         msg = 'output specifier not supported for: "{}" (choose from "{}")'.format(arg,

--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -58,7 +58,8 @@ def pytest_addoption(parser):
     group.addoption('--cov-report', action=StoreReport, default={},
                     metavar='type', type=validate_report,
                     help='type of report to generate: term, term-missing, '
-                    'term-skip-covered, annotate, html, xml (multi-allowed). '
+                    'annotate, html, xml (multi-allowed). '
+                    'term, term-missing maybe followed by ":skip-covered".'
                     'annotate, html and xml may be be followed by ":DEST" '
                     'where DEST specifies the output location.')
     group.addoption('--cov-config', action='store', default='.coveragerc',

--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -16,7 +16,7 @@ class CoverageError(Exception):
 
 def validate_report(arg):
     file_choices = ['annotate', 'html', 'xml']
-    term_choices = ['term', 'term-missing']
+    term_choices = ['term', 'term-missing', 'term-skip-covered']
     all_choices = term_choices + file_choices
     values = arg.split(":", 1)
     report_type = values[0]
@@ -53,7 +53,7 @@ def pytest_addoption(parser):
     group.addoption('--cov-report', action=StoreReport, default={},
                     metavar='type', type=validate_report,
                     help='type of report to generate: term, term-missing, '
-                    'annotate, html, xml (multi-allowed). '
+                    'term-skip-covered, annotate, html, xml (multi-allowed). '
                     'annotate, html and xml may be be followed by ":DEST" '
                     'where DEST specifies the output location.')
     group.addoption('--cov-config', action='store', default='.coveragerc',

--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -567,6 +567,7 @@ parallel = true
     ])
     assert result.ret == 0
 
+
 def test_central_subprocess_no_subscript(testdir):
     script = testdir.makepyfile("""
 import subprocess, sys

--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -883,13 +883,27 @@ SKIP_COVERED_RESULT = '1 file skipped due to complete coverage.'
 
 
 @pytest.mark.skipif('StrictVersion(coverage.__version__) < StrictVersion("4.0")')
-def test_coveragerc_skip_covered(testdir):
+@pytest.mark.parametrize('report_option', [
+    'term-missing:skip-covered',
+    'term:skip-covered'])
+def test_skip_covered_cli(testdir, report_option):
+    testdir.makefile('', coveragerc=SKIP_COVERED_COVERAGERC)
+    script = testdir.makepyfile(SKIP_COVERED_TEST)
+    result = testdir.runpytest('-v',
+                               '--cov=%s' % script.dirpath(),
+                               '--cov-report=%s' % report_option,
+                               script)
+    assert result.ret == 0
+    result.stdout.fnmatch_lines([SKIP_COVERED_RESULT])
+
+
+@pytest.mark.skipif('StrictVersion(coverage.__version__) < StrictVersion("4.0")')
+def test_skip_covered_coveragerc_config(testdir):
     testdir.makefile('', coveragerc=SKIP_COVERED_COVERAGERC)
     script = testdir.makepyfile(SKIP_COVERED_TEST)
     result = testdir.runpytest('-v',
                                '--cov-config=coveragerc',
                                '--cov=%s' % script.dirpath(),
-                               '--cov-report=term-skip-covered',
                                script)
     assert result.ret == 0
     result.stdout.fnmatch_lines([SKIP_COVERED_RESULT])

--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -863,6 +863,38 @@ def test_coveragerc_dist(testdir):
         ['test_coveragerc_dist* %s' % EXCLUDED_RESULT])
 
 
+SKIP_COVERED_COVERAGERC = '''
+[report]
+skip_covered = True
+
+'''
+
+SKIP_COVERED_TEST = '''
+
+def func():
+    return "full coverage"
+
+def test_basic():
+    assert func() == "full coverage"
+
+'''
+
+SKIP_COVERED_RESULT = '1 file skipped due to complete coverage.'
+
+
+@pytest.mark.skipif('StrictVersion(coverage.__version__) < StrictVersion("4.0")')
+def test_coveragerc_skip_covered(testdir):
+    testdir.makefile('', coveragerc=SKIP_COVERED_COVERAGERC)
+    script = testdir.makepyfile(SKIP_COVERED_TEST)
+    result = testdir.runpytest('-v',
+                               '--cov-config=coveragerc',
+                               '--cov=%s' % script.dirpath(),
+                               '--cov-report=term-skip-covered',
+                               script)
+    assert result.ret == 0
+    result.stdout.fnmatch_lines([SKIP_COVERED_RESULT])
+
+
 CLEAR_ENVIRON_TEST = '''
 
 import os


### PR DESCRIPTION
This is a working implementation and works fine with `.coveragerc` and `setup.cfg`.

I've not added relevant docs and test, as i'm still trying to understand those. 

@ionelmc if this looks good, i'll try to add docs and tests. 

Ref: http://coverage.readthedocs.io/en/latest/api_coverage.html#coverage.Coverage.report

closes #114