### PR TITLE
Show errors on insufficient cov

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -14,3 +14,4 @@ Authors
 * Christian Ledermann - https://github.com/cleder
 * Alec Nikolas Reiter - https://github.com/justanr
 * Patrick Lannigan - https://github.com/unholysampler
+* David Szotten - https://github.com/davidszotten

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,10 +1,13 @@
 Changelog
 =========
 
-2.2.2 (tba)
+2.3.0 (tba)
 ------------------
 
 * Add support for specifying output location for html, xml, and annotate report.
+* Fix bug hiding test failure when cov-fail-under failed
+* Error if coverage fails to find the source instead of just printing the error
+
 
 2.2.1 (2016-01-30)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,8 @@ Changelog
 
 * Add support for specifying output location for html, xml, and annotate report.
 * Fix bug hiding test failure when cov-fail-under failed
-* Error if coverage fails to find the source instead of just printing the error
+* For coverage >= 4.0, match the default behaviour of `coverage report` and
+  error if coverage fails to find the source instead of just printing a warning
 
 
 2.2.1 (2016-01-30)

--- a/src/pytest_cov/compat.py
+++ b/src/pytest_cov/compat.py
@@ -5,6 +5,8 @@ except ImportError:
 
 import pytest
 
+StringIO  # pyflakes, this is for re-export
+
 
 if hasattr(pytest, 'hookimpl'):
     hookwrapper = pytest.hookimpl(hookwrapper=True)

--- a/src/pytest_cov/compat.py
+++ b/src/pytest_cov/compat.py
@@ -1,0 +1,29 @@
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
+import pytest
+
+
+if hasattr(pytest, 'hookimpl'):
+    hookwrapper = pytest.hookimpl(hookwrapper=True)
+else:
+    hookwrapper = pytest.mark.hookwrapper
+
+
+class SessionWrapper(object):
+    def __init__(self, session):
+        self._session = session
+        if hasattr(session, 'testsfailed'):
+            self._attr = 'testsfailed'
+        else:
+            self._attr = '_testsfailed'
+
+    @property
+    def testsfailed(self):
+        return getattr(self._session, self._attr)
+
+    @testsfailed.setter
+    def testsfailed(self, value):
+        setattr(self._session, self._attr, value)

--- a/src/pytest_cov/engine.py
+++ b/src/pytest_cov/engine.py
@@ -4,13 +4,11 @@ import os
 import random
 import socket
 import sys
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
 
 import coverage
 from coverage.data import CoverageData
+
+from .compat import StringIO
 
 
 class CovController(object):

--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -224,11 +224,11 @@ class CovPlugin(object):
         if self._should_report() and self._failed_cov_total():
             markup = {'red': True, 'bold': True}
             msg = (
-                'Required test coverage of %d%% not '
-                'reached. Total coverage: %.2f%%'
+                '\nFAIL Required test coverage of %d%% not '
+                'reached. Total coverage: %.2f%%\n'
                 % (self.options.cov_fail_under, self.cov_total)
             )
-            terminalreporter.write(msg + '\n', **markup)
+            terminalreporter.write(msg, **markup)
 
     def pytest_runtest_setup(self, item):
         if os.getpid() != self.pid:

--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -1,5 +1,7 @@
 """Coverage plugin for pytest."""
 import os
+from StringIO import StringIO
+
 import pytest
 import argparse
 from coverage.misc import CoverageException
@@ -117,6 +119,8 @@ class CovPlugin(object):
         self.pid = None
         self.cov = None
         self.cov_controller = None
+        self.cov_report = StringIO()
+        self.cov_total = None
         self.failed = False
         self._started = False
         self.options = options
@@ -180,30 +184,51 @@ class CovPlugin(object):
         self.cov_controller.testnodedown(node, error)
     pytest_testnodedown.optionalhook = True
 
-    def pytest_sessionfinish(self, session, exitstatus):
-        """Delegate to our implementation."""
-        self.failed = exitstatus != 0
+    def _should_report(self):
+        return not (self.failed and self.options.no_cov_on_fail)
+
+    def _failed_cov_total(self):
+        cov_fail_under = self.options.cov_fail_under
+        return cov_fail_under is not None and self.cov_total < cov_fail_under
+
+    # we need to wrap pytest_runtestloop. by the time pytest_sessionfinish
+    # runs, it's too late to set testsfailed
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_runtestloop(self, session):
+        outcome = yield
+
+        self.failed = bool(session.testsfailed)
         if self.cov_controller is not None:
             self.cov_controller.finish()
 
+        if self._should_report():
+            try:
+                self.cov_total = self.cov_controller.summary(self.cov_report)
+            except CoverageException as exc:
+                raise pytest.UsageError(
+                    'Failed to generate report: %s\n' % exc
+                )
+            assert self.cov_total is not None, 'Test coverage should never be `None`'
+            if self._failed_cov_total():
+                # make sure we get the EXIT_TESTSFAILED exit code
+                session.testsfailed += 1
+
     def pytest_terminal_summary(self, terminalreporter):
-        """Delegate to our implementation."""
         if self.cov_controller is None:
             return
-        if not (self.failed and self.options.no_cov_on_fail):
-            try:
-                total = self.cov_controller.summary(terminalreporter.writer)
-            except CoverageException as exc:
-                terminalreporter.writer.write('Failed to generate report: %s\n' % exc)
-                total = 0
-            assert total is not None, 'Test coverage should never be `None`'
-            cov_fail_under = self.options.cov_fail_under
-            if cov_fail_under is not None and total < cov_fail_under:
-                raise pytest.UsageError(
-                    'Required test coverage of %d%% not '
-                    'reached. Total coverage: %.2f%%\n'
-                    % (self.options.cov_fail_under, total)
-                )
+        if self.cov_total is None:
+            # report generation failed (error raised above)
+            return
+
+        terminalreporter.write('\n' + self.cov_report.getvalue())
+        if self._should_report() and self._failed_cov_total():
+            markup = {'red': True, 'bold': True}
+            msg = (
+                'Required test coverage of %d%% not '
+                'reached. Total coverage: %.2f%%'
+                % (self.options.cov_fail_under, self.cov_total)
+            )
+            terminalreporter.write(msg + '\n', **markup)
 
     def pytest_runtest_setup(self, item):
         if os.getpid() != self.pid:

--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -216,11 +216,13 @@ class CovPlugin(object):
     def pytest_terminal_summary(self, terminalreporter):
         if self.cov_controller is None:
             return
+
+        terminalreporter.write('\n' + self.cov_report.getvalue())
+
         if self.cov_total is None:
             # report generation failed (error raised above)
             return
 
-        terminalreporter.write('\n' + self.cov_report.getvalue())
         if self._should_report() and self._failed_cov_total():
             markup = {'red': True, 'bold': True}
             msg = (

--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -223,12 +223,12 @@ class CovPlugin(object):
             # we shouldn't report, or report generation failed (error raised above)
             return
 
-        terminalreporter.write('\n' + self.cov_report.getvalue())
+        terminalreporter.write('\n' + self.cov_report.getvalue() + '\n')
 
         if self._failed_cov_total():
             markup = {'red': True, 'bold': True}
             msg = (
-                '\nFAIL Required test coverage of %d%% not '
+                'FAIL Required test coverage of %d%% not '
                 'reached. Total coverage: %.2f%%\n'
                 % (self.options.cov_fail_under, self.cov_total)
             )

--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -1,6 +1,9 @@
 """Coverage plugin for pytest."""
 import os
-from StringIO import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 import pytest
 import argparse

--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -219,13 +219,13 @@ class CovPlugin(object):
         if self.cov_controller is None:
             return
 
-        terminalreporter.write('\n' + self.cov_report.getvalue())
-
         if self.cov_total is None:
-            # report generation failed (error raised above)
+            # we shouldn't report, or report generation failed (error raised above)
             return
 
-        if self._should_report() and self._failed_cov_total():
+        terminalreporter.write('\n' + self.cov_report.getvalue())
+
+        if self._failed_cov_total():
             markup = {'red': True, 'bold': True}
             msg = (
                 '\nFAIL Required test coverage of %d%% not '

--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -195,7 +195,7 @@ class CovPlugin(object):
     # runs, it's too late to set testsfailed
     @compat.hookwrapper
     def pytest_runtestloop(self, session):
-        outcome = yield
+        yield
 
         compat_session = compat.SessionWrapper(session)
 

--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -649,8 +649,10 @@ def test_invalid_coverage_source(testdir):
                                script)
 
     result.stdout.fnmatch_lines([
-        '*- coverage: platform *, python * -*',
         '*10 passed*'
+    ])
+    result.stderr.fnmatch_lines([
+        'ERROR: Failed to generate report: No data to report.',
     ])
     assert result.ret != 0
     matching_lines = [line for line in result.outlines if '%' in line]

--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -8,7 +8,7 @@ import coverage
 import py
 import pytest
 import virtualenv
-from process_tests import TestProcess
+from process_tests import TestProcess as _TestProcess
 from process_tests import dump_on_error
 from process_tests import wait_for_strings
 
@@ -760,7 +760,7 @@ def test_cover_looponfail(testdir, monkeypatch):
     testdir.makeconftest(CONFTEST)
     script = testdir.makepyfile(BASIC_TEST)
 
-    monkeypatch.setattr(testdir, 'run', lambda *args: TestProcess(*map(str, args)))
+    monkeypatch.setattr(testdir, 'run', lambda *args: _TestProcess(*map(str, args)))
     with testdir.runpytest('-v',
                            '--cov=%s' % script.dirpath(),
                            '--looponfail',

--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -4,7 +4,6 @@ import subprocess
 import sys
 from distutils.version import StrictVersion
 
-from _pytest.main import EXIT_USAGEERROR
 import coverage
 import py
 import pytest
@@ -653,7 +652,7 @@ def test_invalid_coverage_source(testdir):
         '*- coverage: platform *, python * -*',
         '*10 passed*'
     ])
-    assert result.ret == EXIT_USAGEERROR
+    assert result.ret != 0
     matching_lines = [line for line in result.outlines if '%' in line]
     assert not matching_lines
 

--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -887,7 +887,7 @@ def test_dist_boxed(testdir):
 
 def test_not_started_plugin_does_not_fail(testdir):
     plugin = pytest_cov.plugin.CovPlugin(None, None, start=False)
-    plugin.pytest_sessionfinish(None, None)
+    plugin.pytest_runtestloop(None)
     plugin.pytest_terminal_summary(None)
 
 

--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -4,6 +4,7 @@ import subprocess
 import sys
 from distutils.version import StrictVersion
 
+from _pytest.main import EXIT_USAGEERROR
 import coverage
 import py
 import pytest
@@ -640,7 +641,7 @@ def test_dist_subprocess_not_collocated(testdir, tmpdir):
     assert result.ret == 0
 
 
-def test_empty_report(testdir):
+def test_invalid_coverage_source(testdir):
     script = testdir.makepyfile(SCRIPT)
 
     result = testdir.runpytest('-v',
@@ -652,7 +653,7 @@ def test_empty_report(testdir):
         '*- coverage: platform *, python * -*',
         '*10 passed*'
     ])
-    assert result.ret == 0
+    assert result.ret == EXIT_USAGEERROR
     matching_lines = [line for line in result.outlines if '%' in line]
     assert not matching_lines
 

--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -652,9 +652,19 @@ def test_invalid_coverage_source(testdir):
         '*10 passed*'
     ])
     result.stderr.fnmatch_lines([
-        'ERROR: Failed to generate report: No data to report.',
+        'Coverage.py warning: No data was collected.'
     ])
-    assert result.ret != 0
+
+    if StrictVersion(coverage.__version__) <= StrictVersion("3.8"):
+        # older `coverage report` doesn't error on missing imports
+        assert result.ret == 0
+    else:
+        # newer `coverage report` errors on missing importts
+        result.stderr.fnmatch_lines([
+            'ERROR: Failed to generate report: No data to report.',
+        ])
+        assert result.ret != 0
+
     matching_lines = [line for line in result.outlines if '%' in line]
     assert not matching_lines
 

--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -419,6 +419,20 @@ def test_no_cov_on_fail(testdir):
     result.stdout.fnmatch_lines(['*1 failed*'])
 
 
+def test_cov_and_failure_report_on_fail(testdir):
+    script = testdir.makepyfile(SCRIPT + SCRIPT_FAIL)
+
+    result = testdir.runpytest('-v',
+                               '--cov=%s' % script.dirpath(),
+                               '--cov-fail-under=100',
+                               script)
+
+    assert 'coverage: platform' in result.stdout.str()
+    assert 'Required test coverage of 100% not reached' in result.stdout.str()
+    assert 'assert False' in result.stdout.str()
+    result.stdout.fnmatch_lines(['*10 failed*'])
+
+
 def test_dist_combine_racecondition(testdir):
     script = testdir.makepyfile("""
 import pytest

--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -428,7 +428,7 @@ def test_cov_and_failure_report_on_fail(testdir):
                                script)
 
     assert 'coverage: platform' in result.stdout.str()
-    assert 'Required test coverage of 100% not reached' in result.stdout.str()
+    assert 'FAIL Required test coverage of 100% not reached' in result.stdout.str()
     assert 'assert False' in result.stdout.str()
     result.stdout.fnmatch_lines(['*10 failed*'])
 


### PR DESCRIPTION
don't hide failed tests when cov-fail-under fails

c.f. #108 

also tweaks failure semantics slightly, see changelog (hence minor version bump)