### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -48,7 +48,7 @@ To set up `pytest-cov` for local development:
 
    Now you can make your changes locally.
 
-4. When you're done making changes, run all the checks, doc builder and spell checker with `tox <http://tox.readthedocs.org/en/latest/install.html>`_ one command::
+4. When you're done making changes, run all the checks, doc builder and spell checker with `tox <https://tox.readthedocs.io/en/latest/install.html>`_ one command::
 
     tox
 

--- a/docs/releasing.rst
+++ b/docs/releasing.rst
@@ -17,7 +17,7 @@ The process for releasing should follow these steps:
     git push --tags
 #. Wait for `AppVeyor <https://ci.appveyor.com/project/schlamar/pytest-cov>`_
    and `Travis <https://travis-ci.org/schlamar/pytest-cov>`_ to give the green builds.
-#. Check that the docs on `ReadTheDocs <https://readthedocs.org/projects/pytest-cov>`_ are built.
+#. Check that the docs on `ReadTheDocs <https://pytest-cov.readthedocs.io/>`_ are built.
 #. Make sure you have a clean checkout, run ``git status`` to verify.
 #. Manually clean temporary files (that are ignored and won't show up in ``git status``)::
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.