### PR TITLE
Dont fail on xdist with bare --cov

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -15,3 +15,4 @@ Authors
 * Alec Nikolas Reiter - https://github.com/justanr
 * Patrick Lannigan - https://github.com/unholysampler
 * David Szotten - https://github.com/davidszotten
+* Michael Elovskikh - https://github.com/wronglink

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ Changelog
 * For coverage >= 4.0, match the default behaviour of `coverage report` and
   error if coverage fails to find the source instead of just printing a warning.
   Contributed by David Szotten in `PR#116 <https://github.com/pytest-dev/pytest-cov/pull/116>`_.
+* Fixed bug occurred when bare ``--cov`` parameter was used with xdist.
+  Contributed by Michael Elovskikh in `PR#120 <https://github.com/pytest-dev/pytest-cov/pull/120>`_.
 
 
 2.2.1 (2016-01-30)

--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -93,6 +93,8 @@ def pytest_configure(config):
         if not config.pluginmanager.hasplugin('_cov'):
             if not config.option.cov_report:
                 config.option.cov_report = ['term']
+            if config.option.cov_source == [True]:
+                config.option.cov_source = None
 
             plugin = CovPlugin(config.option, config.pluginmanager,
                                start=False)

--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -911,6 +911,23 @@ def test_dist_boxed(testdir):
     assert result.ret == 0
 
 
+@pytest.mark.skipif('sys.platform == "win32"')
+def test_dist_bare_cov(testdir):
+    script = testdir.makepyfile(SCRIPT_SIMPLE)
+
+    result = testdir.runpytest('-v',
+                               '--cov',
+                               '-n', '1',
+                               script)
+
+    result.stdout.fnmatch_lines([
+        '*- coverage: platform *, python * -*',
+        'test_dist_bare_cov* %s*' % SCRIPT_SIMPLE_RESULT,
+        '*1 passed*'
+    ])
+    assert result.ret == 0
+
+
 def test_not_started_plugin_does_not_fail(testdir):
     plugin = pytest_cov.plugin.CovPlugin(None, None, start=False)
     plugin.pytest_runtestloop(None)
@@ -1041,4 +1058,3 @@ def test_do_not_append_coverage(testdir, opts):
         'test_1* 0%',
         'test_2* %s*' % SCRIPT2_RESULT,
     ])
-


### PR DESCRIPTION
`pytest-cov` used to fail on such parameters combination:

```bash
py.test --cov -n1
```

I've added small fixup of `cov_source` parameter, if empty `--cov` is used.

Closes #110 