### PR TITLE
Fix definition of `cov` fixture for pytest 3

### DIFF
--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -254,10 +254,9 @@ class CovPlugin(object):
             self.cov = None
 
 
-def pytest_funcarg__cov(request):
-    """A pytest funcarg that provides access to the underlying coverage
-    object.
-    """
+@pytest.fixture
+def cov(request):
+    """A pytest fixture to provide access to the underlying coverage object."""
 
     # Check with hasplugin to avoid getplugin exception in older pytest.
     if request.config.pluginmanager.hasplugin('_cov'):


### PR DESCRIPTION
With pytest 3.0 (not released yet) the following warning gets emitted:

> WC1 None pytest_funcarg__cov: declaring fixtures using
> "pytest_funcarg__" prefix is deprecated and scheduled to be removed in
> pytest 4.0.  Please remove the prefix and use the @pytest.fixture decorator
> instead.