### PR TITLE
Pass a type instead of string to parser.addoption

### DIFF
--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -68,7 +68,7 @@ def pytest_addoption(parser):
     group.addoption('--no-cov-on-fail', action='store_true', default=False,
                     help='do not report coverage if test run fails, '
                          'default: False')
-    group.addoption('--cov-fail-under', action='store', metavar='MIN', type='int',
+    group.addoption('--cov-fail-under', action='store', metavar='MIN', type=int,
                     help='Fail if the total coverage is less than MIN.')
     group.addoption('--cov-append', action='store_true', default=False,
                     help='do not delete coverage but append to current, '


### PR DESCRIPTION
Otherwise we get this DeprecationWarning with pytest 3.0:

      [...]
      File ".../pytest_cov/plugin.py", line 72, in pytest_addoption
        help='Fail if the total coverage is less than MIN.')
      File ".../_pytest/config.py", line 482, in addoption
        self._anonymous.addoption(*opts, **attrs)
      File ".../_pytest/config.py", line 708, in addoption
        option = Argument(*optnames, **attrs)
      File ".../_pytest/config.py", line 609, in __init__
        stacklevel=3)
    DeprecationWarning: type argument to addoption() is a string 'int'. For parsearg this should be a type. (options: ('--cov-fail-under',))