### PR TITLE
add option --cov-summary to show coverage summary in terminal

### DIFF
--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -76,6 +76,9 @@ def pytest_addoption(parser):
     group.addoption('--cov-append', action='store_true', default=False,
                     help='do not delete coverage but append to current, '
                          'default: False')
+    group.addoption('--cov-summary', action='store_true', default=False,
+                    help='show coverage summary in terminal, '
+                         'default: False')
 
 
 @pytest.mark.tryfirst
@@ -257,6 +260,11 @@ class CovPlugin(object):
             return
 
         terminalreporter.write('\n' + self.cov_report.getvalue() + '\n')
+
+        if self.options.cov_summary:
+            if self.options.cov_fail_under is not None:
+                terminalreporter.write('Required coverage: %d%%\n' % self.options.cov_fail_under)
+            terminalreporter.write('Total coverage: %.2f%%\n' % self.cov_total)
 
         if self._failed_cov_total():
             markup = {'red': True, 'bold': True}

--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -1126,3 +1126,24 @@ def test_do_not_append_coverage(testdir, opts):
         'test_1* 0%',
         'test_2* %s*' % SCRIPT2_RESULT,
     ])
+
+
+def test_cov_summary(testdir):
+    script = testdir.makepyfile(SCRIPT)
+
+    result = testdir.runpytest('-v',
+                               '--cov=%s' % script.dirpath(),
+                               '--cov-summary',
+                               script)
+    result.stdout.fnmatch_lines([
+        'Total coverage: *'
+    ])
+    result = testdir.runpytest('-v',
+                               '--cov=%s' % script.dirpath(),
+                               '--cov-fail-under=50',
+                               '--cov-summary',
+                               script)
+    result.stdout.fnmatch_lines([
+        'Required coverage: *',
+        'Total coverage: *'
+    ])


### PR DESCRIPTION
In our case, we want to see a brief summary about the total coverage and required coverage in CI console, instead of printing a full term report or opening the html report. So I add an option `--cov-summary` to output coverage summary in terminal.