### PR TITLE
show total coverage when required test coverage reached

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ class GeneratePTH(Command):
                     'exec(%r)' % sh.read().replace('    ', ' ')
                 )
 
+
 setup(
     name='pytest-cov',
     version='2.4.0',

--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -258,13 +258,21 @@ class CovPlugin(object):
 
         terminalreporter.write('\n' + self.cov_report.getvalue() + '\n')
 
-        if self._failed_cov_total():
-            markup = {'red': True, 'bold': True}
-            msg = (
-                'FAIL Required test coverage of %d%% not '
-                'reached. Total coverage: %.2f%%\n'
-                % (self.options.cov_fail_under, self.cov_total)
-            )
+        if self.options.cov_fail_under is not None and self.options.cov_fail_under > 0:
+            if self.cov_total < self.options.cov_fail_under:
+                markup = {'red': True, 'bold': True}
+                msg = (
+                    'FAIL Required test coverage of %d%% not '
+                    'reached. Total coverage: %.2f%%\n'
+                    % (self.options.cov_fail_under, self.cov_total)
+                )
+            else:
+                markup = {'green': True}
+                msg = (
+                    'Required test coverage of %d%% '
+                    'reached. Total coverage: %.2f%%\n'
+                    % (self.options.cov_fail_under, self.cov_total)
+                )
             terminalreporter.write(msg, **markup)
 
     def pytest_runtest_setup(self, item):

--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -296,6 +296,9 @@ def test_cov_min_100(testdir):
                                script)
 
     assert result.ret != 0
+    result.stdout.fnmatch_lines([
+        'FAIL Required test coverage of 100% not reached. Total coverage: *%'
+    ])
 
 
 def test_cov_min_50(testdir):
@@ -308,6 +311,9 @@ def test_cov_min_50(testdir):
                                script)
 
     assert result.ret == 0
+    result.stdout.fnmatch_lines([
+        'Required test coverage of 50% reached. Total coverage: *%'
+    ])
 
 
 def test_cov_min_no_report(testdir):
@@ -320,6 +326,9 @@ def test_cov_min_no_report(testdir):
                                script)
 
     assert result.ret == 0
+    result.stdout.fnmatch_lines([
+        'Required test coverage of 50% reached. Total coverage: *%'
+    ])
 
 
 def test_central_nonspecific(testdir):


### PR DESCRIPTION
This pr is the updated version of #140.

In our case, we specify `--cov-report=html` and `--cov-fail-under=85`, we want to see the total coverage in CI console at a glance, instead of printing a full term report or opening the html report, even when required test coverage(85%) is reached. So if total coverage is close to required, we may take actions in advance.