### PR TITLE
Fix typo in plugin docu

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -18,7 +18,7 @@ Alternatively you can have this in ``tox.ini`` (if you're using `Tox <https://to
         COV_CORE_CONFIG={toxinidir}/.coveragerc
         COV_CORE_DATAFILE={toxinidir}/.coverage.eager
 
-And in ``pytest.ini`` / ``tox.ini`` / ``setup.cfg``:
+And in ``pytest.ini`` / ``tox.ini`` / ``setup.cfg``::
 
     [tool:pytest]
     addopts =


### PR DESCRIPTION
A colon was missing so the code block was no code block, but a quote.