### PR TITLE
Added in the doc a useful example to help integrate pytest-cov.

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -25,6 +25,12 @@ Note that this plugin controls some options and setting the option in the config
 effect.  These include specifying source to be measured (source option) and all data file handling
 (data_file and parallel options).
 
+If you wish to always add pytest-cov with pytest, you can use ``addopts`` under ``pytest`` or ``tool:pytest`` section.
+For example: ::
+
+    [tool:pytest]
+    addopts = --cov=<project-name> --cov-report html
+
 Caveats
 =======
 


### PR DESCRIPTION
It took me some time to figure out how to have pytest-cov be run automatically with pytest when I switched to a 100% conf-file (personally I used `setup.cfg`) driven testing.

I think an example in the docs would be helpful and non-invasive.

Open to different wordings.

I didn't add myself into the `AUTHORS.rst` as I don't believe this is anywhere near authoring work.

Regards!