### PR TITLE
--report-type='' implies no --cov-fail-under

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -23,3 +23,4 @@ Authors
 * Zoltan Kozma - https://github.com/kozmaz87
 * Francis Niu - https://flniu.github.io
 * Jannis Leidel - https://github.com/jezdez
+* Terence Honles - https://github.com/terencehonles

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+2.5.2 (2018-04-14)
+------------------
+
+* Specifying ``--cov-report=`` will not output any report information and
+  will not check minimum coverage which may be specified with
+  ``--cov-fail-under=MIN`` or through the config. This change is to allow
+  using ``--cov-append`` in future runs without reporting failure too early.
+
+
 2.5.1 (2017-05-11)
 ------------------
 

--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -206,7 +206,8 @@ class CovPlugin(object):
     pytest_testnodedown.optionalhook = True
 
     def _should_report(self):
-        return not (self.failed and self.options.no_cov_on_fail)
+        return (self.options.cov_report
+                and not (self.failed and self.options.no_cov_on_fail))
 
     def _failed_cov_total(self):
         cov_fail_under = self.options.cov_fail_under

--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -309,6 +309,20 @@ def test_cov_min_100(testdir):
     ])
 
 
+def test_cov_min_100_no_report(testdir):
+    script = testdir.makepyfile(SCRIPT)
+
+    result = testdir.runpytest('-v',
+                               '--cov=%s' % script.dirpath(),
+                               '--cov-report=',
+                               '--cov-fail-under=100',
+                               script)
+
+    assert result.ret == 0
+    assert ('FAIL Required test coverage of 100% not reached.'
+            not in result.stdout.str())
+
+
 def test_cov_min_50(testdir):
     script = testdir.makepyfile(SCRIPT)
 
@@ -324,7 +338,7 @@ def test_cov_min_50(testdir):
     ])
 
 
-def test_cov_min_no_report(testdir):
+def test_cov_min_50_no_report(testdir):
     script = testdir.makepyfile(SCRIPT)
 
     result = testdir.runpytest('-v',
@@ -334,9 +348,7 @@ def test_cov_min_no_report(testdir):
                                script)
 
     assert result.ret == 0
-    result.stdout.fnmatch_lines([
-        'Required test coverage of 50% reached. Total coverage: *%'
-    ])
+    assert 'Required test coverage of 50% reached.' not in result.stdout.str()
 
 
 def test_central_nonspecific(testdir, prop):


### PR DESCRIPTION
Specifying `--cov-report=` will not output any report information and will not check minimum coverage which may be specified with `--cov-fail-under=MIN` or through the config. This change is to allow using `--cov-append` in future runs without reporting failure too early.

With this change, on the final build you will need to generate at least `--cov-report=term` or run `coverage report` directly

-------------------------

I made this change because I want to declare `fail_under` in my coverage config (for me it lives in `setup.cfg` which passes some other common options by using `addopts` (like mentioned in #195)), but my current test setup requires at least 2 passes running `pytest` which initially the sequence would be:

```sh
ENV_VAR=value pytest --cov-report=
ENV_VAR=other_value pytest --cov-append
```

However, without the proposed PR the first test fails and I would have to ignore the exit code (which is not appropriate because the test suite may have actually failed)

With this change I can leave `fail_under` as part of my coverage config instead of having to hardcode it in the CI runner or add an additional file/configuration option.