### PR TITLE
fix DoctestItem has no attribute fixturenames

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -23,3 +23,4 @@ Authors
 * Zoltan Kozma - https://github.com/kozmaz87
 * Francis Niu - https://flniu.github.io
 * Jannis Leidel - https://github.com/jezdez
+* Terence Honles - https://github.com/terencehonles

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+2.5.2 (2017-04-14)
+------------------
+* Fix DoctestItem has no attribute fixturenames (regression from `PR#78`)
+
 2.5.1 (2017-05-11)
 ------------------
 

--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -286,7 +286,8 @@ class CovPlugin(object):
 
     @compat.hookwrapper
     def pytest_runtest_call(self, item):
-        if item.get_marker("no_cover") or "no_cover" in item.fixturenames:
+        if (item.get_marker('no_cover')
+                or 'no_cover' in getattr(item, 'fixturenames', ())):
             self.cov_controller.pause()
             yield
             self.cov_controller.resume()


### PR DESCRIPTION
fixes regression in a02e1c83a273517dd82ef638cbb7717e5f52bbc9 (#78) which makes `pytest --cov` not friendly with `pytest --doctest-modules`