### PR TITLE
tests: test_central_subprocess_no_subscript: remove omit

### DIFF
--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -698,8 +698,6 @@ def test_foo():
     testdir.makefile('', coveragerc="""
 [run]
 parallel = true
-omit =
-    */__init__.py
 """)
     result = testdir.runpytest('-v',
                                '--cov-config=coveragerc',


### PR DESCRIPTION
It does not seem to be necessary.

Found while looking into https://github.com/pytest-dev/pytest-cov/issues/204.