### PR TITLE
Allow remote nodes to get source modules from .coveragerc

### DIFF
--- a/src/pytest_cov/engine.py
+++ b/src/pytest_cov/engine.py
@@ -268,8 +268,9 @@ class DistSlave(CovController):
         if not self.is_collocated:
             master_topdir = self.config.slaveinput['cov_master_topdir']
             slave_topdir = self.topdir
-            self.cov_source = [source.replace(master_topdir, slave_topdir)
-                               for source in self.cov_source]
+            if self.cov_source is not None:
+                self.cov_source = [source.replace(master_topdir, slave_topdir)
+                                   for source in self.cov_source]
             self.cov_config = self.cov_config.replace(master_topdir, slave_topdir)
 
         # Erase any previous data and start coverage.


### PR DESCRIPTION
Although you can normally use `--cov` without an argument to read the modules to be covered from `.coveragerc`, this currently doesn't work for non-collocated xdist workers because the code doesn't account for the possibility that `self.cov_source` is `None`:

```
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "_pytest/main.py", line 176, in wrap_session
INTERNALERROR>     config.hook.pytest_sessionstart(session=session)
INTERNALERROR>   File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/pluggy/__init__.py", line 617, in __call__
INTERNALERROR>     return self._hookexec(self, self._nonwrappers + self._wrappers, kwargs)
INTERNALERROR>   File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/pluggy/__init__.py", line 222, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR>   File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/pluggy/__init__.py", line 216, in <lambda>
INTERNALERROR>     firstresult=hook.spec_opts.get('firstresult'),
INTERNALERROR>   File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/pluggy/callers.py", line 201, in _multicall
INTERNALERROR>     return outcome.get_result()
INTERNALERROR>   File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/pluggy/callers.py", line 77, in get_result
INTERNALERROR>     _reraise(*ex)  # noqa
INTERNALERROR>   File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/pluggy/callers.py", line 180, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/pytest_cov/plugin.py", line 195, in pytest_sessionstart
INTERNALERROR>     self.start(engine.DistSlave, session.config, nodeid)
INTERNALERROR>   File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/pytest_cov/plugin.py", line 174, in start
INTERNALERROR>     self.cov_controller.start()
INTERNALERROR>   File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/pytest_cov/engine.py", line 250, in start
INTERNALERROR>     for source in self.cov_source]
INTERNALERROR> TypeError: 'NoneType' object is not iterable
```

This change just accounts for that possibility and tests that it loads the modules to be covered from the configuration file in this case.