### PR TITLE
Fix race condition in test

### DIFF
--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -929,6 +929,7 @@ def target_fn():
 def test_run_target():
     p = multiprocessing.Process(target=target_fn)
     p.start()
+    time.sleep(0.5)
     event.wait(1)
     p.terminate()
     p.join()
@@ -941,7 +942,7 @@ def test_run_target():
 
     result.stdout.fnmatch_lines([
         '*- coverage: platform *, python * -*',
-        'test_multiprocessing_subprocess* 15 * 100%*',
+        'test_multiprocessing_subprocess* 16 * 100%*',
         '*1 passed*'
     ])
     assert result.ret == 0


### PR DESCRIPTION
This test has been intermittently failing recently both for [PRs](https://travis-ci.org/pytest-dev/pytest-cov/builds/407787617) and [master](https://travis-ci.org/pytest-dev/pytest-cov/builds/310846695).  The original process sometimes manages to terminate the spawned process right after it calls `event.set()`, so it never gets to `time.sleep(5)` yielding less than the expected 100% coverage.  I think this 0.5 second wait should be enough for the spawned process to always hit the `wait` statement without slowing the test down perceptibly.  I tried 0.1 seconds first, but the [pypy tests still failed in Travis](https://travis-ci.org/pytest-dev/pytest-cov/builds/408073549) with that.