### PR TITLE
Travis CI: Python 3.7 requires Xenial and sudo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,21 +85,33 @@ matrix:
     - python: '3.7'
       env:
         - TOXENV=py37-t35-c44
+      dist: xenial
+      sudo: required
     - python: '3.7'
       env:
         - TOXENV=py37-t35-c45
+      dist: xenial
+      sudo: required
     - python: '3.7'
       env:
         - TOXENV=py37-t36-c44
+      dist: xenial
+      sudo: required
     - python: '3.7'
       env:
         - TOXENV=py37-t36-c45
+      dist: xenial
+      sudo: required
     - python: '3.7'
       env:
         - TOXENV=py37-t37-c44
+      dist: xenial
+      sudo: required
     - python: '3.7'
       env:
         - TOXENV=py37-t37-c45
+      dist: xenial
+      sudo: required
     - python: 'pypy-5.4'
       env:
         - TOXENV=pypy-t35-c44


### PR DESCRIPTION
Python 3.7 was added to the test matrix in https://github.com/pytest-dev/pytest-cov/commit/3cf7f73488e81d0ed5b30ef19ab85c41b9a9a7af.

However, the 3.7 builds are failing as it requires Xenial and sudo. 

Let's enable those for just the 3.7 builds.

See https://github.com/travis-ci/travis-ci/issues/9815 for more info.

---

By the way, do you know roughly when the next release will be?