### PR TITLE
docs/plugins.rst: use --cov with addopts

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -21,5 +21,4 @@ Alternatively you can have this in ``tox.ini`` (if you're using `Tox <https://to
 And in ``pytest.ini`` / ``tox.ini`` / ``setup.cfg``::
 
     [tool:pytest]
-    addopts =
-        --cov-append
+    addopts = --cov --cov-append


### PR DESCRIPTION
Without `--cov` pytest-cov will not track coverage at all.

[ci skip]