### PR TITLE
Avoid "Module already imported" warning from pytest

### DIFF
--- a/src/pytest_cov/__init__.py
+++ b/src/pytest_cov/__init__.py
@@ -1,1 +1,2 @@
+"""pytest-cov: avoid already-imported warning: PYTEST_DONT_REWRITE."""
 __version__ = "2.6.0"


### PR DESCRIPTION
> Module already imported so cannot be rewritten

Fixes https://github.com/pytest-dev/pytest-cov/issues/211