### PR TITLE
Fix test_cover_looponfail test

### DIFF
--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -1022,7 +1022,8 @@ def test_cover_looponfail(testdir, monkeypatch):
     testdir.makeconftest(CONFTEST)
     script = testdir.makepyfile(BASIC_TEST)
 
-    monkeypatch.setattr(testdir, 'run', lambda *args: _TestProcess(*map(str, args)))
+    monkeypatch.setattr(testdir, 'run',
+                        lambda *args, **kwargs: _TestProcess(*map(str, args)))
     with testdir.runpytest('-v',
                            '--cov=%s' % script.dirpath(),
                            '--looponfail',


### PR DESCRIPTION
Pytest 3.9.0 introduced a timeout for ``Testdir.runpytest_subprocess()``
and ``Testdir.run()``. So API has been changed and now it looks like
``run(self, *cmdargs, **kwargs)``.

Hence to comply with the new API it needs to fix a lambda's definition.

Fixes: https://github.com/pytest-dev/pytest-cov/issues/247
Signed-off-by: Stanislav Levin <slev@altlinux.org>