### PR TITLE
Use get_closest_marker

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ setup(
         'cover', 'coverage', 'pytest', 'py.test', 'distributed', 'parallel',
     ],
     install_requires=[
-        'pytest>=2.9',
+        'pytest>=3.6',
         'coverage>=4.4'
     ],
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',

--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -293,7 +293,7 @@ class CovPlugin(object):
 
     @compat.hookwrapper
     def pytest_runtest_call(self, item):
-        if (item.get_marker('no_cover')
+        if (item.get_closest_marker('no_cover')
                 or 'no_cover' in getattr(item, 'fixturenames', ())):
             self.cov_controller.pause()
             yield


### PR DESCRIPTION
Fixes pytest-cov with pytest 4.1.
Requires pytest 3.6+ now.