### PR TITLE
tox.ini: do not use "pytest" inside of "{posargs}"

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ deps =
 pip_pre = true
 
 commands =
-    {posargs:pytest -vv}
+    pytest {posargs:-vv}
 
 [testenv:spell]
 setenv =
@@ -71,6 +71,3 @@ commands =
     python setup.py check --strict --metadata --restructuredtext
     check-manifest {toxinidir}
     flake8 src tests setup.py
-
-
-


### PR DESCRIPTION
The typical use case is pass args to pytest, not change the executable
(pytest) itself:

> tox -e … -- -k foo