### PR TITLE
Skip hook if cov disabled

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -28,3 +28,4 @@ Authors
 * Jeremy Bowman - https://github.com/jmbowman
 * Samuel Giffard - https://github.com/Mulugruntz
 * Семён Марьясин - https://github.com/MarSoft
+* Alexander Shadchin - https://github.com/shadchin

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+2.6.2 (2019-02-05)
+------------------
+
+* Fixed ``'NoneType' object has no attribute 'configure_node'`` issue.
+  Contributed by Alexander Shadchin in `#263 <https://github.com/pytest-dev/pytest-cov/pull/263>`_.
+
 2.6.1 (2019-01-07)
 ------------------
 

--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -195,7 +195,8 @@ class CovPlugin(object):
 
         Mark this hook as optional in case xdist is not installed.
         """
-        self.cov_controller.configure_node(node)
+        if not self._disabled:
+            self.cov_controller.configure_node(node)
     pytest_configure_node.optionalhook = True
 
     def pytest_testnodedown(self, node, error):
@@ -203,7 +204,8 @@ class CovPlugin(object):
 
         Mark this hook as optional in case xdist is not installed.
         """
-        self.cov_controller.testnodedown(node, error)
+        if not self._disabled:
+            self.cov_controller.testnodedown(node, error)
     pytest_testnodedown.optionalhook = True
 
     def _should_report(self):

--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -1439,3 +1439,13 @@ def test_double_cov2(testdir):
         '*1 passed*'
     ])
     assert result.ret == 0
+
+
+def test_cov_and_no_cov(testdir):
+    script = testdir.makepyfile(SCRIPT_SIMPLE)
+    result = testdir.runpytest('-v',
+                               '--cov', '--no-cov',
+                               '-n', '1',
+                               script)
+
+    assert result.ret == 0


### PR DESCRIPTION
1. Install `pytest-cov` and `pytest-xdist`
2. Make file `test_cov.py`:
```(python)
def test_cov():
    assert 1 == 1
```
3. Make file `setup.cfg`:
```
[tool:pytest]
addopts =
    --cov=.
```
4. Run `pytest --no-cov -n 2`:
```
==================================================================================================================== test session starts ====================================================================================================================
platform linux2 -- Python 2.7.12, pytest-4.2.0, py-1.7.0, pluggy-0.8.1
rootdir: /home/shadchin/tets_cov, inifile: setup.cfg
plugins: xdist-1.26.1, forked-1.0.1, cov-2.6.1
gw0 C / gw1 IINTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/home/shadchin/tets_cov/venv/local/lib/python2.7/site-packages/_pytest/main.py", line 201, in wrap_session
INTERNALERROR>     config.hook.pytest_sessionstart(session=session)
INTERNALERROR>   File "/home/shadchin/tets_cov/venv/local/lib/python2.7/site-packages/pluggy/hooks.py", line 284, in __call__
INTERNALERROR>     return self._hookexec(self, self.get_hookimpls(), kwargs)
INTERNALERROR>   File "/home/shadchin/tets_cov/venv/local/lib/python2.7/site-packages/pluggy/manager.py", line 68, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR>   File "/home/shadchin/tets_cov/venv/local/lib/python2.7/site-packages/pluggy/manager.py", line 62, in <lambda>
INTERNALERROR>     firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
INTERNALERROR>   File "/home/shadchin/tets_cov/venv/local/lib/python2.7/site-packages/pluggy/callers.py", line 208, in _multicall
INTERNALERROR>     return outcome.get_result()
INTERNALERROR>   File "/home/shadchin/tets_cov/venv/local/lib/python2.7/site-packages/pluggy/callers.py", line 81, in get_result
INTERNALERROR>     _reraise(*ex)  # noqa
INTERNALERROR>   File "/home/shadchin/tets_cov/venv/local/lib/python2.7/site-packages/pluggy/callers.py", line 187, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/home/shadchin/tets_cov/venv/local/lib/python2.7/site-packages/xdist/dsession.py", line 81, in pytest_sessionstart
INTERNALERROR>     nodes = self.nodemanager.setup_nodes(putevent=self.queue.put)
INTERNALERROR>   File "/home/shadchin/tets_cov/venv/local/lib/python2.7/site-packages/xdist/workermanage.py", line 68, in setup_nodes
INTERNALERROR>     nodes.append(self.setup_node(spec, putevent))
INTERNALERROR>   File "/home/shadchin/tets_cov/venv/local/lib/python2.7/site-packages/xdist/workermanage.py", line 77, in setup_node
INTERNALERROR>     node.setup()
INTERNALERROR>   File "/home/shadchin/tets_cov/venv/local/lib/python2.7/site-packages/xdist/workermanage.py", line 246, in setup
INTERNALERROR>     self.config.hook.pytest_configure_node(node=self)
INTERNALERROR>   File "/home/shadchin/tets_cov/venv/local/lib/python2.7/site-packages/pluggy/hooks.py", line 284, in __call__
INTERNALERROR>     return self._hookexec(self, self.get_hookimpls(), kwargs)
INTERNALERROR>   File "/home/shadchin/tets_cov/venv/local/lib/python2.7/site-packages/pluggy/manager.py", line 68, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR>   File "/home/shadchin/tets_cov/venv/local/lib/python2.7/site-packages/pluggy/manager.py", line 62, in <lambda>
INTERNALERROR>     firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
INTERNALERROR>   File "/home/shadchin/tets_cov/venv/local/lib/python2.7/site-packages/pluggy/callers.py", line 208, in _multicall
INTERNALERROR>     return outcome.get_result()
INTERNALERROR>   File "/home/shadchin/tets_cov/venv/local/lib/python2.7/site-packages/pluggy/callers.py", line 81, in get_result
INTERNALERROR>     _reraise(*ex)  # noqa
INTERNALERROR>   File "/home/shadchin/tets_cov/venv/local/lib/python2.7/site-packages/pluggy/callers.py", line 187, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/home/shadchin/tets_cov/venv/local/lib/python2.7/site-packages/pytest_cov/plugin.py", line 198, in pytest_configure_node
INTERNALERROR>     self.cov_controller.configure_node(node)
INTERNALERROR> AttributeError: 'NoneType' object has no attribute 'configure_node'
```

edit @nicoddemus: Fixes https://github.com/pytest-dev/pytest-xdist/issues/411