### PR TITLE
reqs: testing: use process-tests==2.0.2 again

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -129,7 +129,7 @@ setup(
         'testing': [
             'fields',
             'hunter',
-            'process-tests==2.0.0',
+            'process-tests==2.0.2',
             'pytest-xdist==1.25.0',
             'six',
             'virtualenv',


### PR DESCRIPTION
This was accidentally reverted/lost in a5a1f61, and is required for
AppVeyor.