### PR TITLE
Add docstring to no_cover fixture

### DIFF
--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -302,6 +302,7 @@ class CovPlugin(object):
 
 @pytest.fixture
 def no_cover():
+    """A pytest fixture to disable coverage."""
     pass
 
 


### PR DESCRIPTION
Currently running `pytest --fixtures` in a project using pytest-cov returns an ugly:
```bash
no_cover
    .../pytest_cov/plugin.py:306: no docstring available
```
This PR fix that.
