### PR TITLE
Makes coverage disabled message a debugging one

### DIFF
--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -95,7 +95,7 @@ def _prepare_cov_source(cov_source):
 
 @pytest.mark.tryfirst
 def pytest_load_initial_conftests(early_config, parser, args):
-    if early_config.known_args_namespace.cov_source:
+    if early_config.known_args_namespace.cov_source and not early_config.known_args_namespace.collectonly:
         plugin = CovPlugin(early_config.known_args_namespace, early_config.pluginmanager)
         early_config.pluginmanager.register(plugin, '_cov')
 

--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -1,6 +1,5 @@
 """Coverage plugin for pytest."""
 import argparse
-import logging
 import os
 import warnings
 

--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -1,5 +1,6 @@
 """Coverage plugin for pytest."""
 import argparse
+import logging
 import os
 import warnings
 
@@ -248,7 +249,7 @@ class CovPlugin(object):
     def pytest_terminal_summary(self, terminalreporter):
         if self._disabled:
             message = 'Coverage disabled via --no-cov switch!'
-            terminalreporter.write('WARNING: %s\n' % message, red=True, bold=True)
+            logging.debug(message)
             if pytest.__version__ >= '3.8':
                 warnings.warn(pytest.PytestWarning(message))
             else:

--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -248,12 +248,7 @@ class CovPlugin(object):
 
     def pytest_terminal_summary(self, terminalreporter):
         if self._disabled:
-            message = 'Coverage disabled via --no-cov switch!'
-            logging.debug(message)
-            if pytest.__version__ >= '3.8':
-                warnings.warn(pytest.PytestWarning(message))
-            else:
-                terminalreporter.config.warn(code='COV-1', message=message)
+            terminalreporter.write('NOTICE: Coverage disabled via --no-cov switch!\n', purple=True, bold=True)
             return
         if self.cov_controller is None:
             return

--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -542,7 +542,7 @@ def test_no_cov(testdir):
                                '-rw',
                                script)
     result.stdout.fnmatch_lines_random([
-        'WARNING: Coverage disabled via --no-cov switch!',
+        'NOTICE: Coverage disabled via --no-cov switch!',
         '*Coverage disabled via --no-cov switch!',
     ])
 


### PR DESCRIPTION
Avoids poluting stdout with a warning message which is unlikely to be
caused by an accident (adding --no-cov switch)

Fixes: #284