### PR TITLE
Don't be fooled by "coverage" in a path.

### DIFF
--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -1658,7 +1658,11 @@ def test_disabled_output(testdir):
                                '--cov-report=',
                                script)
 
-    assert 'coverage' not in result.stdout.str()
+    stdout = result.stdout.str()
+    # We don't want the path to the executable to fail the test if we happen
+    # to put the project in a directory with "coverage" in it.
+    stdout = stdout.replace(sys.executable, "<SYS.EXECUTABLE>")
+    assert 'coverage' not in stdout
     assert result.ret == 0
 
 


### PR DESCRIPTION
One test is asserting that "coverage" doesn't appear in the output. But I cloned this repo into "~/coverage/pytest-cov" so the word appears.  I tweaked the test to prevent a misdiagnosis.

The failing test was this:
```
______________________________________________________________________________________ test_disabled_output ______________________________________________________________________________________
/Users/ned/coverage/pytest-cov/tests/test_pytest_cov.py:1661: in test_disabled_output
    assert 'coverage' not in result.stdout.str()
E   AssertionError: assert 'coverage' not in '=====================...====================='
E     'coverage' is contained here:
E       ============================= test session starts ==============================
E       platform darwin -- Python 2.7.14, pytest-3.10.1, py-1.8.0, pluggy-0.12.0 -- /Users/ned/coverage/pytest-cov/.tox/py27-t310-c45/bin/python
E     ?                                                                                        ++++++++
E       cachedir: .pytest_cache
E       rootdir: /private/var/folders/j2/gr3cj3jn63s5q8g3bjvw57hm0000gp/T/pytest-of-ned/pytest-340/test_disabled_output0, inifile:
E       plugins: forked-1.0.2, cov-2.7.1, xdist-1.27.0
E       collecting ... collected 10 items
E
E       test_disabled_output.py::test_foo[0] PASSED                              [ 10%]
E       test_disabled_output.py::test_foo[1] PASSED                              [ 20%]
E       test_disabled_output.py::test_foo[2] PASSED                              [ 30%]
E       test_disabled_output.py::test_foo[3] PASSED                              [ 40%]
E       test_disabled_output.py::test_foo[4] PASSED                              [ 50%]
E       test_disabled_output.py::test_foo[5] PASSED                              [ 60%]
E       test_disabled_output.py::test_foo[6] PASSED                              [ 70%]
E       test_disabled_output.py::test_foo[7] PASSED                              [ 80%]
E       test_disabled_output.py::test_foo[8] PASSED                              [ 90%]
E       test_disabled_output.py::test_foo[9] PASSED                              [100%]
E
E
E
E       ========================== 10 passed in 0.08 seconds ===========================
```