### PR TITLE
tox.ini: make "tox -e pypy" etc work

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,21 +10,27 @@ envlist =
 extras = testing
 setenv =
     PYTHONUNBUFFERED=yes
+
+    # Use env vars for (optional) pinning of deps.
+    t310: _DEP_PYTEST=pytest==3.10.1
+    t40:  _DEP_PYTEST=pytest==4.0.2
+    t41:  _DEP_PYTEST=pytest==4.1.1
+    t43:  _DEP_PYTEST=pytest==4.3.1
+    t44:  _DEP_PYTEST=pytest==4.4.2
+    t45:  _DEP_PYTEST=pytest==4.5.0
+
+    {t310,t40,t41,t43}: _DEP_PYTESTXDIST=pytest-xdist==1.27.0
+    {t44,t45}: _DEP_PYTESTXDIST=pytest-xdist==1.28.0
+
+    c44: _DEP_COVERAGE=coverage==4.4.2
+    c45: _DEP_COVERAGE=coverage==4.5.3
+
 passenv =
     *
 deps =
-    t310: pytest==3.10.1
-    t40: pytest==4.0.2
-    t41: pytest==4.1.1
-    t43: pytest==4.3.1
-    t44: pytest==4.4.2
-    t45: pytest==4.5.0
-
-    {t310,t40,t41,t43}: pytest-xdist==1.27.0
-    {t44,t45}: pytest-xdist==1.28.0
-
-    c44: coverage==4.4.2
-    c45: coverage==4.5.3
+    {env:_DEP_PYTEST:pytest}
+    {env:_DEP_PYTESTXDIST:pytest-xdist}
+    {env:_DEP_COVERAGE:coverage}
 pip_pre = true
 commands =
     pytest {posargs:-vv}


### PR DESCRIPTION
This uses internal env vars for deps, allowing to install them always
(unpinned).