### PR TITLE
tox.ini: default to Coverage.py < 5

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ passenv =
 deps =
     {env:_DEP_PYTEST:pytest}
     {env:_DEP_PYTESTXDIST:pytest-xdist}
-    {env:_DEP_COVERAGE:coverage}
+    {env:_DEP_COVERAGE:coverage<5}
 pip_pre = true
 commands =
     pytest {posargs:-vv}


### PR DESCRIPTION
Otherwise tests will fail currently, e.g.
`tox -e py37 -- tests/test_pytest_cov.py::test_dist_missing_data`