### PR TITLE
Fix for Python 4: replace unsafe PY3 with PY2

### DIFF
--- a/examples/adhoc-layout/example/__init__.py
+++ b/examples/adhoc-layout/example/__init__.py
@@ -1,13 +1,13 @@
 
 import sys
 
-PY3 = sys.version_info[0] == 3
+PY2 = sys.version_info[0] == 2
 
 
-if PY3:
+if PY2:
     def add(a, b):
-        return a + b
+        return b + a
 
 else:
     def add(a, b):
-        return b + a
+        return a + b

--- a/examples/src-layout/src/example/__init__.py
+++ b/examples/src-layout/src/example/__init__.py
@@ -1,13 +1,13 @@
 
 import sys
 
-PY3 = sys.version_info[0] == 3
+PY2 = sys.version_info[0] == 2
 
 
-if PY3:
+if PY2:
     def add(a, b):
-        return a + b
+        return b + a
 
 else:
     def add(a, b):
-        return b + a
+        return a + b


### PR DESCRIPTION
We don't yet know if 3.10 or 4.0 will follow Python 3.9, but whichever it is, it will probably happen in [2020 when Python 3.9 reaches beta](https://www.python.org/dev/peps/pep-0596/#schedule) and work begins on Python 3.9+1.

Some examples are like this:

```python
PY3 = sys.version_info[0] == 3

if PY3:
    print("Python 3+ code")
else:
    print("Python 2 code")
```


When run on Python 4, this will run the Python 2 code! Instead, use `PY2`.

Found using https://github.com/asottile/flake8-2020:
```console
$ pip install -U flake8-2020
...
$ flake8 --select YTT
./examples/src-layout/src/example/__init__.py:4:7: YTT201 `sys.version_info[0] == 3` referenced (python4), use `>=`
./examples/adhoc-layout/example/__init__.py:4:7: YTT201 `sys.version_info[0] == 3` referenced (python4), use `>=`
```
