### PR TITLE
Drop support for EOL Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,6 @@ jobs:
       python: '2.7'
     - env: TOXENV=py27-pytest46-xdist27-coverage45
       python: '2.7'
-    - env: TOXENV=py34-pytest310-xdist27-coverage45
-      python: '3.4'
-    - env: TOXENV=py34-pytest46-xdist27-coverage45
-      python: '3.4'
     - env: TOXENV=py35-pytest310-xdist27-coverage45
       python: '3.5'
     - env: TOXENV=py35-pytest46-xdist27-coverage45

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,6 @@ environment:
   matrix:
     - TOXENV: check
     - TOXENV: 'py27-pytest310-xdist27-coverage45,py27-pytest46-xdist27-coverage45,py27-pytest310-xdist27-coverage50,py27-pytest46-xdist27-coverage50'
-    - TOXENV: 'py34-pytest310-xdist27-coverage45,py34-pytest46-xdist27-coverage45'
     - TOXENV: 'py35-pytest310-xdist27-coverage45,py35-pytest46-xdist27-coverage45,py35-pytest310-xdist27-coverage50,py35-pytest46-xdist27-coverage50'
     - TOXENV: 'py36-pytest310-xdist27-coverage45,py36-pytest46-xdist27-coverage45,py36-pytest310-xdist27-coverage50,py36-pytest46-xdist27-coverage50,py36-pytest46-xdist29-coverage45,py36-pytest46-xdist29-coverage50,py36-pytest46-xdist30-coverage45,py36-pytest46-xdist30-coverage50,py36-pytest51-xdist29-coverage45,py36-pytest51-xdist29-coverage50,py36-pytest51-xdist30-coverage45,py36-pytest51-xdist30-coverage50,py36-pytest52-xdist29-coverage45,py36-pytest52-xdist29-coverage50,py36-pytest52-xdist30-coverage45,py36-pytest52-xdist30-coverage50'
     - TOXENV: 'py37-pytest310-xdist27-coverage45,py37-pytest46-xdist27-coverage45,py37-pytest310-xdist27-coverage50,py37-pytest46-xdist27-coverage50,py37-pytest46-xdist29-coverage45,py37-pytest46-xdist29-coverage50,py37-pytest46-xdist30-coverage45,py37-pytest46-xdist30-coverage50,py37-pytest51-xdist29-coverage45,py37-pytest51-xdist29-coverage50,py37-pytest51-xdist30-coverage45,py37-pytest51-xdist30-coverage50,py37-pytest52-xdist29-coverage45,py37-pytest52-xdist29-coverage50,py37-pytest52-xdist30-coverage45,py37-pytest52-xdist30-coverage50'

--- a/ci/templates/appveyor.yml
+++ b/ci/templates/appveyor.yml
@@ -4,7 +4,6 @@ environment:
   matrix:
     - TOXENV: check
     - TOXENV: '{{ py27_environments|join(",") }}'
-    - TOXENV: '{{ py34_environments|join(",") }}'
     - TOXENV: '{{ py35_environments|join(",") }}'
     - TOXENV: '{{ py36_environments|join(",") }}'
     - TOXENV: '{{ py37_environments|join(",") }}'

--- a/docs/releasing.rst
+++ b/docs/releasing.rst
@@ -26,7 +26,7 @@ The process for releasing should follow these steps:
    These files need to be removed to force distutils/setuptools to rebuild everything and recreate the egg-info metadata.
 #. Build the dists::
 
-        python3.4 setup.py clean --all sdist bdist_wheel
+        python3 setup.py clean --all sdist bdist_wheel
 
 #. Verify that the resulting archives (found in ``dist/``) are good.
 #. Upload the sdist and wheel with twine::

--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
@@ -125,7 +124,7 @@ setup(
         'pytest>=3.6',
         'coverage>=4.4'
     ],
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     extras_require={
         'testing': [
             'fields',

--- a/tox.ini
+++ b/tox.ini
@@ -15,16 +15,10 @@ setenv =
 
     # Use env vars for (optional) pinning of deps.
     pytest310: _DEP_PYTEST=pytest==3.10.1
-    pytest40:  _DEP_PYTEST=pytest==4.0.2
-    pytest41:  _DEP_PYTEST=pytest==4.1.1
-    pytest43:  _DEP_PYTEST=pytest==4.3.1
-    pytest44:  _DEP_PYTEST=pytest==4.4.2
-    pytest45:  _DEP_PYTEST=pytest==4.5.0
     pytest46:  _DEP_PYTEST=pytest==4.6.5
     pytest51:  _DEP_PYTEST=pytest==5.1.3
     pytest52:  _DEP_PYTEST=pytest==5.2.0
 
-    xdist22: _DEP_PYTESTXDIST=pytest-xdist==1.22.0
     xdist27: _DEP_PYTESTXDIST=pytest-xdist==1.27.0
     xdist28: _DEP_PYTESTXDIST=pytest-xdist==1.28.0
     xdist29: _DEP_PYTESTXDIST=pytest-xdist==1.29.0

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 [tox]
 envlist =
     check
-    py{27,34,35,36,37,py,py3}-pytest{310,46}-xdist27-coverage45
+    py{27,35,36,37,py,py3}-pytest{310,46}-xdist27-coverage45
     py{27,35,36,37,py,py3}-pytest{310,46}-xdist27-coverage50
     py{36,37,38,py3}-pytest{46,51,52}-xdist{29,30}-coverage{45,50}
     docs


### PR DESCRIPTION
Python  3.4 is EOL and no longer receiving security updates (or any updates) from the core Python team.

Version | Release date | Supported until
--- | ---------- | ----------
2.7 | 2010-07-03 | 2020-01-01
3.4 | 2014-03-16 | 2019-03-16

* https://en.wikipedia.org/wiki/CPython#Version_history

The latest pytest 5.x series has dropped 3.4 (and 2.7):

* https://pytest.org/en/latest/py27-py34-deprecation.html

There's not a huge amount of code changes from dropping 3.4, but the biggest benefit is reducing the build matrix, which is currently a hefty 34 jobs and 30+ minutes.