### PR TITLE
Avoid importing coverage for test runs that don't need it

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -37,3 +37,4 @@ Authors
 * Martín Gaitán - https://github.com/mgaitan
 * Hugo van Kemenade - https://github.com/hugovk
 * Michael Manganiello - https://github.com/adamantike
+* Anders Hovmöller - https://github.com/boxed

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Changelog
 
 * Fixed ``RemovedInPytest4Warning`` when using Pytest 3.10.
   Contributed by Michael Manganiello in `#354 <https://github.com/pytest-dev/pytest-cov/pull/354>`_.
+* Made pytest startup faster when plugin not active by lazy-importing. 
+  Contributed by Anders Hovmöller in `#339 <https://github.com/pytest-dev/pytest-cov/pull/339>`_.
 
 2.8.1 (2019-10-05)
 ------------------

--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -5,11 +5,9 @@ import warnings
 
 import coverage
 import pytest
-from coverage.misc import CoverageException
 
 from . import compat
 from . import embed
-from . import engine
 
 PYTEST_VERSION = tuple(map(int, pytest.__version__.split('.')[:3]))
 
@@ -160,6 +158,10 @@ class CovPlugin(object):
             self.options.cov_report = {}
         self.options.cov_source = _prepare_cov_source(self.options.cov_source)
 
+        # import engine lazily here to avoid importing
+        # it for unit tests that don't need it
+        from . import engine
+
         if is_dist and start:
             self.start(engine.DistMaster)
         elif start:
@@ -201,6 +203,10 @@ class CovPlugin(object):
             # Coverage can be disabled because it does not cooperate with debuggers well.
             self._disabled = True
             return
+
+        # import engine lazily here to avoid importing
+        # it for unit tests that don't need it
+        from . import engine
 
         self.pid = os.getpid()
         if self._is_worker(session):
@@ -256,6 +262,11 @@ class CovPlugin(object):
             self.cov_controller.finish()
 
         if not self._is_worker(session) and self._should_report():
+
+            # import coverage lazily here to avoid importing
+            # it for unit tests that don't need it
+            from coverage.misc import CoverageException
+
             try:
                 self.cov_total = self.cov_controller.summary(self.cov_report)
             except CoverageException as exc:


### PR DESCRIPTION
This saves me ~0.1s when running tests without coverage where this plugin is installed.