### PR TITLE
handle exception, otherwise p.close() will hang

### DIFF
--- a/docs/subprocess-support.rst
+++ b/docs/subprocess-support.rst
@@ -31,8 +31,12 @@ Thus you need to make sure your ``multiprocessing.Pool`` gets a nice and clean e
         p = Pool(5)
         try:
             print(p.map(f, [1, 2, 3]))
-        finally:
+        except:
+            raise
+            p.terminate()
+        else:
             p.close()  # Marks the pool as closed.
+        finally:
             p.join()   # Waits for workers to exit.
 
 

--- a/docs/subprocess-support.rst
+++ b/docs/subprocess-support.rst
@@ -32,8 +32,8 @@ Thus you need to make sure your ``multiprocessing.Pool`` gets a nice and clean e
         try:
             print(p.map(f, [1, 2, 3]))
         except:
-            raise
             p.terminate()
+            raise
         else:
             p.close()  # Marks the pool as closed.
         finally:

--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -1233,6 +1233,7 @@ def test_run_target():
         raise
     else:
         # new in python 3.7
+        import sys
         if sys.version_info >= (3, 7):
             p.close()
     finally:

--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -1231,9 +1231,10 @@ def test_run_target():
     except:
         p.terminate()
         raise
-    # new in python 3.7
-    #else:
-    #    p.close()
+    else:
+        # new in python 3.7
+        if sys.version_info >= (3, 7):
+            p.close()
     finally:
         p.join()
 ''')

--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -1079,8 +1079,12 @@ def test_run_target():
         p = multiprocessing.Pool(3)
         try:
             p.map(target_fn, [i * 3 + j for j in range(3)])
-        finally:
+        except:
             p.terminate()
+            raise
+        else:
+            p.close()
+        finally:
             p.join()
 ''' % ''.join('''if a == %r:
         return a
@@ -1220,11 +1224,17 @@ def target_fn():
 
 def test_run_target():
     p = multiprocessing.Process(target=target_fn)
-    p.start()
-    time.sleep(0.5)
-    event.wait(1)
-    p.terminate()
-    p.join()
+    try:
+        p.start()
+        time.sleep(0.5)
+        event.wait(1)
+    except:
+        p.terminate()
+        raise
+    else:
+        p.close()
+    finally:
+        p.join()
 ''')
 
     result = testdir.runpytest('-v',

--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -1236,7 +1236,7 @@ def test_run_target():
         # new in python 3.7
         import sys
         if sys.version_info >= (3, 7):
-            p.close()        
+            p.close()
 ''')
 
     result = testdir.runpytest('-v',

--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -1100,7 +1100,7 @@ def test_run_target():
     assert not testdir.tmpdir.listdir(".coverage.*")
     result.stdout.fnmatch_lines([
         '*- coverage: platform *, python * -*',
-        'test_multiprocessing_pool* 100%*',
+        'test_multiprocessing_pool* 99%*',
         '*1 passed*'
     ])
     assert result.ret == 0
@@ -1232,12 +1232,11 @@ def test_run_target():
         p.terminate()
         raise
     else:
+        p.join()
         # new in python 3.7
         import sys
         if sys.version_info >= (3, 7):
-            p.close()
-    finally:
-        p.join()
+            p.close()        
 ''')
 
     result = testdir.runpytest('-v',

--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -1246,7 +1246,7 @@ def test_run_target():
 
     result.stdout.fnmatch_lines([
         '*- coverage: platform *, python * -*',
-        'test_multiprocessing_process* 16 * 100%*',
+        'test_multiprocessing_process* 22 * 8*%*',
         '*1 passed*'
     ])
     assert result.ret == 0

--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -1231,8 +1231,9 @@ def test_run_target():
     except:
         p.terminate()
         raise
-    else:
-        p.close()
+    # new in python 3.7
+    #else:
+    #    p.close()
     finally:
         p.join()
 ''')


### PR DESCRIPTION
If an exception is raised in f, p.close() and p.join() will hang. We need p.terminate() to handle exception.