### PR TITLE
Reduce test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,52 +21,30 @@ jobs:
     - env: TOXENV=docs
 
     - stage: tests
-      env: TOXENV=py27-pytest310-xdist27-coverage45
+      env: TOXENV=py27-pytest46-xdist27-coverage45
       python: '2.7'
-    - env: TOXENV=py27-pytest46-xdist27-coverage45
-      python: '2.7'
-    - env: TOXENV=py35-pytest310-xdist27-coverage45
-      python: '3.5'
+    - env: TOXENV=py34-pytest46-xdist27-coverage45
+      python: '3.4'
     - env: TOXENV=py35-pytest46-xdist27-coverage45
       python: '3.5'
-    - env: TOXENV=py36-pytest310-xdist27-coverage45
-      python: '3.6'
     - env: TOXENV=py36-pytest46-xdist27-coverage45
       python: '3.6'
-    - env: TOXENV=py37-pytest310-xdist27-coverage45
-      python: '3.7'
     - env: TOXENV=py37-pytest46-xdist27-coverage45
       python: '3.7'
-    - env: TOXENV=pypy-pytest310-xdist27-coverage45
-      python: 'pypy'
     - env: TOXENV=pypy-pytest46-xdist27-coverage45
       python: 'pypy'
-    - env: TOXENV=pypy3-pytest310-xdist27-coverage45
-      python: 'pypy3'
     - env: TOXENV=pypy3-pytest46-xdist27-coverage45
       python: 'pypy3'
-    - env: TOXENV=py27-pytest310-xdist27-coverage50
-      python: '2.7'
     - env: TOXENV=py27-pytest46-xdist27-coverage50
       python: '2.7'
-    - env: TOXENV=py35-pytest310-xdist27-coverage50
-      python: '3.5'
     - env: TOXENV=py35-pytest46-xdist27-coverage50
       python: '3.5'
-    - env: TOXENV=py36-pytest310-xdist27-coverage50
-      python: '3.6'
     - env: TOXENV=py36-pytest46-xdist27-coverage50
       python: '3.6'
-    - env: TOXENV=py37-pytest310-xdist27-coverage50
-      python: '3.7'
     - env: TOXENV=py37-pytest46-xdist27-coverage50
       python: '3.7'
-    - env: TOXENV=pypy-pytest310-xdist27-coverage50
-      python: 'pypy'
     - env: TOXENV=pypy-pytest46-xdist27-coverage50
       python: 'pypy'
-    - env: TOXENV=pypy3-pytest310-xdist27-coverage50
-      python: 'pypy3'
     - env: TOXENV=pypy3-pytest46-xdist27-coverage50
       python: 'pypy3'
     - env: TOXENV=py36-pytest46-xdist29-coverage45

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,101 +23,99 @@ jobs:
     - stage: tests
       env: TOXENV=py27-pytest46-xdist27-coverage45
       python: '2.7'
-    - env: TOXENV=py34-pytest46-xdist27-coverage45
-      python: '3.4'
+    - env: TOXENV=py27-pytest46-xdist27-coverage50
+      python: '2.7'
     - env: TOXENV=py35-pytest46-xdist27-coverage45
+      python: '3.5'
+    - env: TOXENV=py35-pytest46-xdist27-coverage50
       python: '3.5'
     - env: TOXENV=py36-pytest46-xdist27-coverage45
       python: '3.6'
+    - env: TOXENV=py36-pytest46-xdist27-coverage50
+      python: '3.6'
     - env: TOXENV=py37-pytest46-xdist27-coverage45
+      python: '3.7'
+    - env: TOXENV=py37-pytest46-xdist27-coverage50
       python: '3.7'
     - env: TOXENV=pypy-pytest46-xdist27-coverage45
       python: 'pypy'
-    - env: TOXENV=pypy3-pytest46-xdist27-coverage45
-      python: 'pypy3'
-    - env: TOXENV=py27-pytest46-xdist27-coverage50
-      python: '2.7'
-    - env: TOXENV=py35-pytest46-xdist27-coverage50
-      python: '3.5'
-    - env: TOXENV=py36-pytest46-xdist27-coverage50
-      python: '3.6'
-    - env: TOXENV=py37-pytest46-xdist27-coverage50
-      python: '3.7'
     - env: TOXENV=pypy-pytest46-xdist27-coverage50
       python: 'pypy'
+    - env: TOXENV=pypy3-pytest46-xdist27-coverage45
+      python: 'pypy3'
     - env: TOXENV=pypy3-pytest46-xdist27-coverage50
       python: 'pypy3'
     - env: TOXENV=py36-pytest46-xdist29-coverage45
       python: '3.6'
     - env: TOXENV=py36-pytest46-xdist29-coverage50
       python: '3.6'
-    - env: TOXENV=py36-pytest46-xdist30-coverage45
+    - env: TOXENV=py36-pytest46-xdist31-coverage45
       python: '3.6'
-    - env: TOXENV=py36-pytest46-xdist30-coverage50
+    - env: TOXENV=py36-pytest46-xdist31-coverage50
       python: '3.6'
-    - env: TOXENV=py36-pytest52-xdist29-coverage45
+    - env: TOXENV=py36-pytest53-xdist29-coverage45
       python: '3.6'
-    - env: TOXENV=py36-pytest52-xdist29-coverage50
+    - env: TOXENV=py36-pytest53-xdist29-coverage50
       python: '3.6'
-    - env: TOXENV=py36-pytest52-xdist30-coverage45
+    - env: TOXENV=py36-pytest53-xdist31-coverage45
       python: '3.6'
-    - env: TOXENV=py36-pytest52-xdist30-coverage50
+    - env: TOXENV=py36-pytest53-xdist31-coverage50
       python: '3.6'
     - env: TOXENV=py37-pytest46-xdist29-coverage45
       python: '3.7'
     - env: TOXENV=py37-pytest46-xdist29-coverage50
       python: '3.7'
-    - env: TOXENV=py37-pytest46-xdist30-coverage45
+    - env: TOXENV=py37-pytest46-xdist31-coverage45
       python: '3.7'
-    - env: TOXENV=py37-pytest46-xdist30-coverage50
+    - env: TOXENV=py37-pytest46-xdist31-coverage50
       python: '3.7'
-    - env: TOXENV=py37-pytest52-xdist29-coverage45
+    - env: TOXENV=py37-pytest53-xdist29-coverage45
       python: '3.7'
-    - env: TOXENV=py37-pytest52-xdist29-coverage50
+    - env: TOXENV=py37-pytest53-xdist29-coverage50
       python: '3.7'
-    - env: TOXENV=py37-pytest52-xdist30-coverage45
+    - env: TOXENV=py37-pytest53-xdist31-coverage45
       python: '3.7'
-    - env: TOXENV=py37-pytest52-xdist30-coverage50
+    - env: TOXENV=py37-pytest53-xdist31-coverage50
       python: '3.7'
     - env: TOXENV=py38-pytest46-xdist29-coverage45
       python: '3.8'
     - env: TOXENV=py38-pytest46-xdist29-coverage50
       python: '3.8'
-    - env: TOXENV=py38-pytest46-xdist30-coverage45
+    - env: TOXENV=py38-pytest46-xdist31-coverage45
       python: '3.8'
-    - env: TOXENV=py38-pytest46-xdist30-coverage50
+    - env: TOXENV=py38-pytest46-xdist31-coverage50
       python: '3.8'
-    - env: TOXENV=py38-pytest52-xdist29-coverage45
+    - env: TOXENV=py38-pytest53-xdist29-coverage45
       python: '3.8'
-    - env: TOXENV=py38-pytest52-xdist29-coverage50
+    - env: TOXENV=py38-pytest53-xdist29-coverage50
       python: '3.8'
-    - env: TOXENV=py38-pytest52-xdist30-coverage45
+    - env: TOXENV=py38-pytest53-xdist31-coverage45
       python: '3.8'
-    - env: TOXENV=py38-pytest52-xdist30-coverage50
+    - env: TOXENV=py38-pytest53-xdist31-coverage50
       python: '3.8'
     - env: TOXENV=pypy3-pytest46-xdist29-coverage45
       python: 'pypy3'
     - env: TOXENV=pypy3-pytest46-xdist29-coverage50
       python: 'pypy3'
-    - env: TOXENV=pypy3-pytest46-xdist30-coverage45
+    - env: TOXENV=pypy3-pytest46-xdist31-coverage45
       python: 'pypy3'
-    - env: TOXENV=pypy3-pytest46-xdist30-coverage50
+    - env: TOXENV=pypy3-pytest46-xdist31-coverage50
       python: 'pypy3'
-    - env: TOXENV=pypy3-pytest52-xdist29-coverage45
+    - env: TOXENV=pypy3-pytest53-xdist29-coverage45
       python: 'pypy3'
-    - env: TOXENV=pypy3-pytest52-xdist29-coverage50
+    - env: TOXENV=pypy3-pytest53-xdist29-coverage50
       python: 'pypy3'
-    - env: TOXENV=pypy3-pytest52-xdist30-coverage45
+    - env: TOXENV=pypy3-pytest53-xdist31-coverage45
       python: 'pypy3'
-    - env: TOXENV=pypy3-pytest52-xdist30-coverage50
+    - env: TOXENV=pypy3-pytest53-xdist31-coverage50
       python: 'pypy3'
 
     - stage: examples
-      python: '3.6'
+      python: '3.8'
       script: cd $TARGET; tox -v
       env:
           - TARGET=examples/src-layout
-    - python: '3.6'
+    - python: '3.8'
       script: cd $TARGET; tox -v
       env:
           - TARGET=examples/adhoc-layout

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,14 +55,6 @@ jobs:
       python: '3.6'
     - env: TOXENV=py36-pytest46-xdist30-coverage50
       python: '3.6'
-    - env: TOXENV=py36-pytest51-xdist29-coverage45
-      python: '3.6'
-    - env: TOXENV=py36-pytest51-xdist29-coverage50
-      python: '3.6'
-    - env: TOXENV=py36-pytest51-xdist30-coverage45
-      python: '3.6'
-    - env: TOXENV=py36-pytest51-xdist30-coverage50
-      python: '3.6'
     - env: TOXENV=py36-pytest52-xdist29-coverage45
       python: '3.6'
     - env: TOXENV=py36-pytest52-xdist29-coverage50
@@ -78,14 +70,6 @@ jobs:
     - env: TOXENV=py37-pytest46-xdist30-coverage45
       python: '3.7'
     - env: TOXENV=py37-pytest46-xdist30-coverage50
-      python: '3.7'
-    - env: TOXENV=py37-pytest51-xdist29-coverage45
-      python: '3.7'
-    - env: TOXENV=py37-pytest51-xdist29-coverage50
-      python: '3.7'
-    - env: TOXENV=py37-pytest51-xdist30-coverage45
-      python: '3.7'
-    - env: TOXENV=py37-pytest51-xdist30-coverage50
       python: '3.7'
     - env: TOXENV=py37-pytest52-xdist29-coverage45
       python: '3.7'
@@ -103,14 +87,6 @@ jobs:
       python: '3.8'
     - env: TOXENV=py38-pytest46-xdist30-coverage50
       python: '3.8'
-    - env: TOXENV=py38-pytest51-xdist29-coverage45
-      python: '3.8'
-    - env: TOXENV=py38-pytest51-xdist29-coverage50
-      python: '3.8'
-    - env: TOXENV=py38-pytest51-xdist30-coverage45
-      python: '3.8'
-    - env: TOXENV=py38-pytest51-xdist30-coverage50
-      python: '3.8'
     - env: TOXENV=py38-pytest52-xdist29-coverage45
       python: '3.8'
     - env: TOXENV=py38-pytest52-xdist29-coverage50
@@ -126,14 +102,6 @@ jobs:
     - env: TOXENV=pypy3-pytest46-xdist30-coverage45
       python: 'pypy3'
     - env: TOXENV=pypy3-pytest46-xdist30-coverage50
-      python: 'pypy3'
-    - env: TOXENV=pypy3-pytest51-xdist29-coverage45
-      python: 'pypy3'
-    - env: TOXENV=pypy3-pytest51-xdist29-coverage50
-      python: 'pypy3'
-    - env: TOXENV=pypy3-pytest51-xdist30-coverage45
-      python: 'pypy3'
-    - env: TOXENV=pypy3-pytest51-xdist30-coverage50
       python: 'pypy3'
     - env: TOXENV=pypy3-pytest52-xdist29-coverage45
       python: 'pypy3'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,11 +4,11 @@ build: off
 environment:
   matrix:
     - TOXENV: check
-    - TOXENV: 'py27-pytest310-xdist27-coverage45,py27-pytest46-xdist27-coverage45,py27-pytest310-xdist27-coverage50,py27-pytest46-xdist27-coverage50'
-    - TOXENV: 'py35-pytest310-xdist27-coverage45,py35-pytest46-xdist27-coverage45,py35-pytest310-xdist27-coverage50,py35-pytest46-xdist27-coverage50'
-    - TOXENV: 'py36-pytest310-xdist27-coverage45,py36-pytest46-xdist27-coverage45,py36-pytest310-xdist27-coverage50,py36-pytest46-xdist27-coverage50,py36-pytest46-xdist29-coverage45,py36-pytest46-xdist29-coverage50,py36-pytest46-xdist30-coverage45,py36-pytest46-xdist30-coverage50,py36-pytest51-xdist29-coverage45,py36-pytest51-xdist29-coverage50,py36-pytest51-xdist30-coverage45,py36-pytest51-xdist30-coverage50,py36-pytest52-xdist29-coverage45,py36-pytest52-xdist29-coverage50,py36-pytest52-xdist30-coverage45,py36-pytest52-xdist30-coverage50'
-    - TOXENV: 'py37-pytest310-xdist27-coverage45,py37-pytest46-xdist27-coverage45,py37-pytest310-xdist27-coverage50,py37-pytest46-xdist27-coverage50,py37-pytest46-xdist29-coverage45,py37-pytest46-xdist29-coverage50,py37-pytest46-xdist30-coverage45,py37-pytest46-xdist30-coverage50,py37-pytest51-xdist29-coverage45,py37-pytest51-xdist29-coverage50,py37-pytest51-xdist30-coverage45,py37-pytest51-xdist30-coverage50,py37-pytest52-xdist29-coverage45,py37-pytest52-xdist29-coverage50,py37-pytest52-xdist30-coverage45,py37-pytest52-xdist30-coverage50'
-    - TOXENV: 'pypy-pytest310-xdist27-coverage45,pypy-pytest46-xdist27-coverage45,pypy-pytest310-xdist27-coverage50,pypy-pytest46-xdist27-coverage50'
+    - TOXENV: 'py27-pytest46-xdist27-coverage45,py27-pytest46-xdist27-coverage50'
+    - TOXENV: 'py35-pytest46-xdist27-coverage45,py35-pytest46-xdist27-coverage50'
+    - TOXENV: 'py36-pytest46-xdist27-coverage45,py36-pytest46-xdist27-coverage50,py36-pytest46-xdist29-coverage45,py36-pytest46-xdist29-coverage50,py36-pytest46-xdist30-coverage45,py36-pytest46-xdist30-coverage50,py36-pytest51-xdist29-coverage45,py36-pytest51-xdist29-coverage50,py36-pytest51-xdist30-coverage45,py36-pytest51-xdist30-coverage50,py36-pytest52-xdist29-coverage45,py36-pytest52-xdist29-coverage50,py36-pytest52-xdist30-coverage45,py36-pytest52-xdist30-coverage50'
+    - TOXENV: 'py37-pytest46-xdist27-coverage45,py37-pytest46-xdist27-coverage50,py37-pytest46-xdist29-coverage45,py37-pytest46-xdist29-coverage50,py37-pytest46-xdist30-coverage45,py37-pytest46-xdist30-coverage50,py37-pytest51-xdist29-coverage45,py37-pytest51-xdist29-coverage50,py37-pytest51-xdist30-coverage45,py37-pytest51-xdist30-coverage50,py37-pytest52-xdist29-coverage45,py37-pytest52-xdist29-coverage50,py37-pytest52-xdist30-coverage45,py37-pytest52-xdist30-coverage50'
+    - TOXENV: 'pypy-pytest46-xdist27-coverage45,pypy-pytest46-xdist27-coverage50'
 
 init:
   - ps: echo $env:TOXENV

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,8 +6,8 @@ environment:
     - TOXENV: check
     - TOXENV: 'py27-pytest46-xdist27-coverage45,py27-pytest46-xdist27-coverage50'
     - TOXENV: 'py35-pytest46-xdist27-coverage45,py35-pytest46-xdist27-coverage50'
-    - TOXENV: 'py36-pytest46-xdist27-coverage45,py36-pytest46-xdist27-coverage50,py36-pytest46-xdist29-coverage45,py36-pytest46-xdist29-coverage50,py36-pytest46-xdist30-coverage45,py36-pytest46-xdist30-coverage50,py36-pytest52-xdist29-coverage45,py36-pytest52-xdist29-coverage50,py36-pytest52-xdist30-coverage45,py36-pytest52-xdist30-coverage50'
-    - TOXENV: 'py37-pytest46-xdist27-coverage45,py37-pytest46-xdist27-coverage50,py37-pytest46-xdist29-coverage45,py37-pytest46-xdist29-coverage50,py37-pytest46-xdist30-coverage45,py37-pytest46-xdist30-coverage50,py37-pytest52-xdist29-coverage45,py37-pytest52-xdist29-coverage50,py37-pytest52-xdist30-coverage45,py37-pytest52-xdist30-coverage50'
+    - TOXENV: 'py36-pytest46-xdist27-coverage45,py36-pytest46-xdist27-coverage50,py36-pytest46-xdist29-coverage45,py36-pytest46-xdist29-coverage50,py36-pytest46-xdist31-coverage45,py36-pytest46-xdist31-coverage50,py36-pytest53-xdist29-coverage45,py36-pytest53-xdist29-coverage50,py36-pytest53-xdist31-coverage45,py36-pytest53-xdist31-coverage50'
+    - TOXENV: 'py37-pytest46-xdist27-coverage45,py37-pytest46-xdist27-coverage50,py37-pytest46-xdist29-coverage45,py37-pytest46-xdist29-coverage50,py37-pytest46-xdist31-coverage45,py37-pytest46-xdist31-coverage50,py37-pytest53-xdist29-coverage45,py37-pytest53-xdist29-coverage50,py37-pytest53-xdist31-coverage45,py37-pytest53-xdist31-coverage50'
     - TOXENV: 'pypy-pytest46-xdist27-coverage45,pypy-pytest46-xdist27-coverage50'
 
 init:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,8 +6,8 @@ environment:
     - TOXENV: check
     - TOXENV: 'py27-pytest46-xdist27-coverage45,py27-pytest46-xdist27-coverage50'
     - TOXENV: 'py35-pytest46-xdist27-coverage45,py35-pytest46-xdist27-coverage50'
-    - TOXENV: 'py36-pytest46-xdist27-coverage45,py36-pytest46-xdist27-coverage50,py36-pytest46-xdist29-coverage45,py36-pytest46-xdist29-coverage50,py36-pytest46-xdist30-coverage45,py36-pytest46-xdist30-coverage50,py36-pytest51-xdist29-coverage45,py36-pytest51-xdist29-coverage50,py36-pytest51-xdist30-coverage45,py36-pytest51-xdist30-coverage50,py36-pytest52-xdist29-coverage45,py36-pytest52-xdist29-coverage50,py36-pytest52-xdist30-coverage45,py36-pytest52-xdist30-coverage50'
-    - TOXENV: 'py37-pytest46-xdist27-coverage45,py37-pytest46-xdist27-coverage50,py37-pytest46-xdist29-coverage45,py37-pytest46-xdist29-coverage50,py37-pytest46-xdist30-coverage45,py37-pytest46-xdist30-coverage50,py37-pytest51-xdist29-coverage45,py37-pytest51-xdist29-coverage50,py37-pytest51-xdist30-coverage45,py37-pytest51-xdist30-coverage50,py37-pytest52-xdist29-coverage45,py37-pytest52-xdist29-coverage50,py37-pytest52-xdist30-coverage45,py37-pytest52-xdist30-coverage50'
+    - TOXENV: 'py36-pytest46-xdist27-coverage45,py36-pytest46-xdist27-coverage50,py36-pytest46-xdist29-coverage45,py36-pytest46-xdist29-coverage50,py36-pytest46-xdist30-coverage45,py36-pytest46-xdist30-coverage50,py36-pytest52-xdist29-coverage45,py36-pytest52-xdist29-coverage50,py36-pytest52-xdist30-coverage45,py36-pytest52-xdist30-coverage50'
+    - TOXENV: 'py37-pytest46-xdist27-coverage45,py37-pytest46-xdist27-coverage50,py37-pytest46-xdist29-coverage45,py37-pytest46-xdist29-coverage50,py37-pytest46-xdist30-coverage45,py37-pytest46-xdist30-coverage50,py37-pytest52-xdist29-coverage45,py37-pytest52-xdist29-coverage50,py37-pytest52-xdist30-coverage45,py37-pytest52-xdist30-coverage50'
     - TOXENV: 'pypy-pytest46-xdist27-coverage45,pypy-pytest46-xdist27-coverage50'
 
 init:

--- a/ci/templates/.travis.yml
+++ b/ci/templates/.travis.yml
@@ -35,7 +35,7 @@ jobs:
     - stage: examples
 {%- for example in ['src', 'adhoc'] %}{{ '' }}
     {%+ if not loop.first %}- {% else %}  {% endif -%}
-      python: '3.6'
+      python: '3.8'
       script: cd $TARGET; tox -v
       env:
           - TARGET=examples/{{ example }}-layout

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx==1.5.6  # rq.filter: >=1.3,<1.6
-sphinx-py3doc-enhanced-theme
-docutils==0.13.1
+sphinx==2.3.1
+sphinx-py3doc-enhanced-theme==2.4.0
+docutils==0.16
 -e .

--- a/examples/adhoc-layout/tox.ini
+++ b/examples/adhoc-layout/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = clean,py27,py36,report
+envlist = clean,py27,py38,report
 
 [tool:pytest]
 addopts =
@@ -10,21 +10,22 @@ commands = pytest --cov --cov-append --cov-config={toxinidir}/.coveragerc {posar
 deps =
     pytest
     pytest-cov
+    coverage<5
 depends =
-    {py27,py36}: clean
-    report: py27,py36
+    {py27,py38}: clean
+    report: py27,py38
 
 # note that this is necessary to prevent the tests importing the code from your badly laid project
 changedir = tests
 
 [testenv:report]
 skip_install = true
-deps = coverage
+deps = coverage<5
 commands =
     coverage html
     coverage report --fail-under=100
 
 [testenv:clean]
 skip_install = true
-deps = coverage
+deps = coverage<5
 commands = coverage erase

--- a/examples/src-layout/tox.ini
+++ b/examples/src-layout/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = clean,py27,py36,report
+envlist = clean,py27,py38,report
 
 [tool:pytest]
 testpaths = tests
@@ -11,18 +11,19 @@ commands = pytest --cov --cov-append {posargs:-vv}
 deps =
     pytest
     pytest-cov
+    coverage<5
 depends =
-    {py27,py36}: clean
-    report: py27,py36
+    {py27,py38}: clean
+    report: py27,py38
 
 [testenv:report]
 skip_install = true
-deps = coverage
+deps = coverage<5
 commands =
     coverage html
     coverage report --fail-under=100
 
 [testenv:clean]
 skip_install = true
-deps = coverage
+deps = coverage<5
 commands = coverage erase

--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -983,10 +983,8 @@ def test_dist_missing_data(testdir):
                                '--tx=popen//python=%s' % exe,
                                max_worker_restart_0,
                                script)
-
-    assert result.ret == 0
     result.stdout.fnmatch_lines([
-        '*- coverage: failed workers -*'
+        'The following workers failed to return coverage data, ensure that pytest-cov is installed on these workers.'
     ])
 
 

--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -680,8 +680,7 @@ def test_foo(foo):
                                '-n', '5', '-s',
                                script)
     result.stdout.fnmatch_lines([
-        '*- coverage: platform *, python * -*',
-        'test_dist_combine_racecondition* 2002 * 0 * 100%*',
+        'test_dist_combine_racecondition* 0 * 100%*',
         '*1000 passed*'
     ])
 

--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -1018,6 +1018,7 @@ def test_funcarg_not_active(testdir):
 @pytest.mark.skipif("sys.version_info[0] < 3", reason="no context manager api on Python 2")
 @pytest.mark.skipif('sys.platform == "win32"', reason="multiprocessing support is broken on Windows")
 @pytest.mark.skipif('platform.python_implementation() == "PyPy"', reason="often deadlocks on PyPy")
+@pytest.mark.skipif('sys.version_info[:2] == (3, 8)', reason="deadlocks on Python 3.8, see: https://bugs.python.org/issue38227")
 def test_multiprocessing_pool(testdir):
     pytest.importorskip('multiprocessing.util')
 
@@ -1058,6 +1059,7 @@ def test_run_target():
 
 @pytest.mark.skipif('sys.platform == "win32"', reason="multiprocessing support is broken on Windows")
 @pytest.mark.skipif('platform.python_implementation() == "PyPy"', reason="often deadlocks on PyPy")
+@pytest.mark.skipif('sys.version_info[:2] == (3, 8)', reason="deadlocks on Python 3.8, see: https://bugs.python.org/issue38227")
 def test_multiprocessing_pool_terminate(testdir):
     pytest.importorskip('multiprocessing.util')
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,8 @@
 [tox]
 envlist =
     check
-    py{27,34,35,36,37,py,py3}-pytest46-xdist27-coverage45
-    py{27,35,36,37,py,py3}-pytest46-xdist27-coverage50
-    py{36,37,38,py3}-pytest{46,52}-xdist{29,30}-coverage{45,50}
+    py{27,35,36,37,py,py3}-pytest46-xdist27-coverage{45,50}
+    py{36,37,38,py3}-pytest{46,53}-xdist{29,31}-coverage{45,50}
     docs
 
 [testenv]
@@ -14,18 +13,17 @@ setenv =
     PYTHONUNBUFFERED=yes
 
     # Use env vars for (optional) pinning of deps.
-    pytest46:  _DEP_PYTEST=pytest==4.6.5
-    pytest52:  _DEP_PYTEST=pytest==5.2.1
+    pytest46:  _DEP_PYTEST=pytest==4.6.9
+    pytest53:  _DEP_PYTEST=pytest==5.3.2
 
     xdist27: _DEP_PYTESTXDIST=pytest-xdist==1.27.0
     xdist29: _DEP_PYTESTXDIST=pytest-xdist==1.29.0
-    xdist30: _DEP_PYTESTXDIST=pytest-xdist==1.30.0
+    xdist31: _DEP_PYTESTXDIST=pytest-xdist==1.31.0
 
     coverage45: _DEP_COVERAGE=coverage==4.5.4
-    coverage50: _DEP_COVERAGE=coverage==5.0b1
+    coverage50: _DEP_COVERAGE=coverage==5.0.3
     # For testing against a coverage.py working tree.
     coveragedev: _DEP_COVERAGE=-e{env:COVERAGE_HOME}
-
 passenv =
     *
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@
 [tox]
 envlist =
     check
-    py{27,35,36,37,py,py3}-pytest{310,46}-xdist27-coverage45
-    py{27,35,36,37,py,py3}-pytest{310,46}-xdist27-coverage50
+    py{27,34,35,36,37,py,py3}-pytest46-xdist27-coverage45
+    py{27,35,36,37,py,py3}-pytest46-xdist27-coverage50
     py{36,37,38,py3}-pytest{46,51,52}-xdist{29,30}-coverage{45,50}
     docs
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
     check
     py{27,34,35,36,37,py,py3}-pytest46-xdist27-coverage45
     py{27,35,36,37,py,py3}-pytest46-xdist27-coverage50
-    py{36,37,38,py3}-pytest{46,51,52}-xdist{29,30}-coverage{45,50}
+    py{36,37,38,py3}-pytest{46,52}-xdist{29,30}-coverage{45,50}
     docs
 
 [testenv]
@@ -14,13 +14,10 @@ setenv =
     PYTHONUNBUFFERED=yes
 
     # Use env vars for (optional) pinning of deps.
-    pytest310: _DEP_PYTEST=pytest==3.10.1
     pytest46:  _DEP_PYTEST=pytest==4.6.5
-    pytest51:  _DEP_PYTEST=pytest==5.1.3
-    pytest52:  _DEP_PYTEST=pytest==5.2.0
+    pytest52:  _DEP_PYTEST=pytest==5.2.1
 
     xdist27: _DEP_PYTESTXDIST=pytest-xdist==1.27.0
-    xdist28: _DEP_PYTESTXDIST=pytest-xdist==1.28.0
     xdist29: _DEP_PYTESTXDIST=pytest-xdist==1.29.0
     xdist30: _DEP_PYTESTXDIST=pytest-xdist==1.30.0
 


### PR DESCRIPTION
Closes #365.

Similar to the reasoning in #182, I'd like to suggest reducing the build matrix.

There are now 76 jobs (only looking at Travis CI), testing 8 Python versions against 4 pytest versions (spanning 3 major pytest releases), 4 xdist versions and 2 Coverage.py versions.

* Is it really necessary to test against all those old versions?

* Does pytest-cov need to make promises to support old releases?

* Do those projects promise to support so many old releases, or just the most recent?

Further, some two dozen of the build jobs are failing, giving less confidence in the CI/tests as a whole.

https://docs.travis-ci.com/user/customizing-the-build/#Build-Matrix says:

> *All build matrixes are currently limited to a maximum of* **200 JOBS** *for both private and public repositories. If you are on an open-source plan, please remember that Travis CI provides this service free of charge to the community. So please only specify the matrix you actually need.*


# Python

Now: 2.7, 3.4, 3.5, 3.6, 3.7, 3.8, py, py3

I suggest it's not necessary to test EOL Python versions (3.4): pytest and Coverage.py do not support it. --> Removed in https://github.com/pytest-dev/pytest-cov/pull/336.

(Consider also dropping Python 2.7 soon, compare the [pytest plan](https://docs.pytest.org/en/latest/py27-py34-deprecation.html) and create a pytest-cov plan.)

# pytest

Now: 3.10, 4.6, 5.1, 5.2

I suggest it's not needed to test 3.10 (released Nov 2018) at all.

pytest 4.6 is the [last to support Python 2.7 and 3.4](https://docs.pytest.org/en/latest/py27-py34-deprecation.html
), so that is needed whilst they are still needed here.

Only test the latest pytest 5.x, remove 5.1.

# xdist

Now: 1.27, 1.29, 1.30

I'd suggest only testing the latest 1.30, but as this is failing the CI I've not included any xdist changes in this PR.

# Coverage.py

Now 4.5, 5a

Keep these, it is necessary to test both latest Coverage.py 4.5 and the upcoming Coverage.py 5 due to large changes.

# Time improvement

|                            | Before | After |
| -------------------------- | -----: | ----: |
| Travis jobs                | 76     | 49    |
| Travis total resource time | 7h15m  | 4h40m |
| Travis end-to-end time     | 1h15m  |   40m |
| AppVeyor time              | 2h50m  | 1h25m |




Thank you!

