### PR TITLE
Fix comparison against installed PyTest version

### DIFF
--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -12,6 +12,9 @@ from . import embed
 from . import engine
 
 
+PYTEST_VERSION = tuple(map(int, pytest.__version__.split('.')[:3]))
+
+
 class CoverageError(Exception):
     """Indicates that our coverage is too low"""
 
@@ -260,7 +263,7 @@ class CovPlugin(object):
                 message = 'Failed to generate report: %s\n' % exc
                 session.config.pluginmanager.getplugin("terminalreporter").write(
                     'WARNING: %s\n' % message, red=True, bold=True)
-                if pytest.__version__ >= '3.8':
+                if PYTEST_VERSION >= (3, 8):
                     warnings.warn(pytest.PytestWarning(message))
                 else:
                     session.config.warn(code='COV-2', message=message)
@@ -274,7 +277,7 @@ class CovPlugin(object):
         if self._disabled:
             message = 'Coverage disabled via --no-cov switch!'
             terminalreporter.write('WARNING: %s\n' % message, red=True, bold=True)
-            if pytest.__version__ >= '3.8':
+            if PYTEST_VERSION >= (3, 8):
                 warnings.warn(pytest.PytestWarning(message))
             else:
                 terminalreporter.config.warn(code='COV-1', message=message)


### PR DESCRIPTION
With the current code, introduced in #230, the comparison
`pytest.__version__ >= '3.8'` returns the wrong result when using
PyTest 3.10, as `'3.10' < '3.8'` if we use Python's string comparison.

Having `PYTEST_VERSION` as an integer tuple allows us to have simpler
comparisons.

This fixes the following warning when using PyTest 3.10:
```
RemovedInPytest4Warning: config.warn has been deprecated, use warnings.warn instead
```