### PR TITLE
setup.cfg: do not use --tb=short by default

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,6 @@ python_files = test_*.py
 addopts =
     -ra
     --strict
-    --tb=short
     -p pytester
 
 [isort]


### PR DESCRIPTION
It silently ignores `-l` etc, and should be used on-demand only.

Ref: https://github.com/pytest-dev/pytest/issues/494