### PR TITLE
setup.py: "testing" extras_require: add pytest-xdist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -132,6 +132,7 @@ setup(
             'hunter',
             'process-tests==2.0.2',
             'six',
+            'pytest-xdist',
             'virtualenv',
         ]
     },


### PR DESCRIPTION
Tests require it currently, and it is not trivial to make it optional.