### PR TITLE
The context tests were failing on newer coverage

### DIFF
--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -1934,12 +1934,12 @@ def test_cov_and_no_cov(testdir):
 
 
 def find_labels(text, pattern):
-    all_labels = collections.defaultdict(list)
+    all_labels = collections.defaultdict(set)
     lines = text.splitlines()
     for lineno, line in enumerate(lines, start=1):
         labels = re.findall(pattern, line)
         for label in labels:
-            all_labels[label].append(lineno)
+            all_labels[label].add(lineno)
     return all_labels
 
 
@@ -2007,7 +2007,7 @@ def test_contexts(testdir, opts):
         if context == '':
             continue
         data.set_query_context(context)
-        actual = data.lines(test_context_path)
+        actual = set(data.lines(test_context_path))
         assert line_data[label] == actual, "Wrong lines for context {!r}".format(context)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,9 @@ setenv =
     xdist30: _DEP_PYTESTXDIST=pytest-xdist==1.30.0
 
     coverage45: _DEP_COVERAGE=coverage==4.5.4
-    coverage50: _DEP_COVERAGE=coverage==5.0a8
+    coverage50: _DEP_COVERAGE=coverage==5.0b1
+    # For testing against a coverage.py working tree.
+    coveragedev: _DEP_COVERAGE=-e{env:COVERAGE_HOME}
 
 passenv =
     *


### PR DESCRIPTION
but it was because the test was fragile.  This fixes the test.