### PR TITLE
#386 Always enable data_suffix for --cov-append

### DIFF
--- a/src/pytest_cov/engine.py
+++ b/src/pytest_cov/engine.py
@@ -218,6 +218,7 @@ class DistMaster(CovController):
 
         self.cov = coverage.Coverage(source=self.cov_source,
                                      branch=self.cov_branch,
+                                     data_suffix=True,
                                      config_file=self.cov_config)
         self.combining_cov = coverage.Coverage(source=self.cov_source,
                                                branch=self.cov_branch,

--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -1869,6 +1869,29 @@ def test_do_not_append_coverage(testdir, opts, prop):
     ])
 
 
+@pytest.mark.skipif('sys.platform == "win32" and platform.python_implementation() == "PyPy"')
+def test_append_coverage_subprocess(testdir):
+    scripts = testdir.makepyfile(parent_script=SCRIPT_PARENT,
+                                 child_script=SCRIPT_CHILD)
+    parent_script = scripts.dirpath().join('parent_script.py')
+
+    result = testdir.runpytest('-v',
+                               '--cov=%s' % scripts.dirpath(),
+                               '--cov-append',
+                               '--cov-report=term-missing',
+                               '--dist=load',
+                               '--tx=2*popen',
+                               max_worker_restart_0,
+                               parent_script)
+
+    result.stdout.fnmatch_lines([
+        '*- coverage: platform *, python * -*',
+        'child_script* %s*' % CHILD_SCRIPT_RESULT,
+        'parent_script* %s*' % PARENT_SCRIPT_RESULT,
+    ])
+    assert result.ret == 0
+
+
 def test_pth_failure(monkeypatch):
     with open('src/pytest-cov.pth') as fh:
         payload = fh.read()


### PR DESCRIPTION
This push request should fix https://github.com/nedbat/coveragepy/issues/883 and https://github.com/pytest-dev/pytest-cov/issues/386 for users of pytest-cov.

Setting `data_suffix=True` on the [primary coverage instance](https://github.com/pytest-dev/pytest-cov/blob/master/src/pytest_cov/engine.py#L219-L221) will enable `parallel=True` and ensure the coverage processes do not conflict with each other. Because pytest-cov always combines the coverage result this is safe to always enable.