### PR TITLE
Support -Werror with --no-cov

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -38,3 +38,4 @@ Authors
 * Hugo van Kemenade - https://github.com/hugovk
 * Michael Manganiello - https://github.com/adamantike
 * Anders Hovmöller - https://github.com/boxed
+* Zac Hatfield-Dodds - https://zhd.dev

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Future release
+--------------
+
+* ``--no-cov`` can now be use with ``-Werror``.  Contributed by Zac Hatfield-Dodds.
+
+
 2.9.0 (2020-05-22)
 ------------------
 

--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -289,10 +289,6 @@ class CovPlugin(object):
         if self._disabled:
             message = 'Coverage disabled via --no-cov switch!'
             terminalreporter.write('WARNING: %s\n' % message, red=True, bold=True)
-            if PYTEST_VERSION >= (3, 8):
-                warnings.warn(pytest.PytestWarning(message))
-            else:
-                terminalreporter.config.warn(code='COV-1', message=message)
             return
         if self.cov_controller is None:
             return


### PR DESCRIPTION
We still print a warning line to the console if the `--no-cov` option was passed, but skipping the Python warning system allows use of `-Werror` mode as well.

Looking back through the git history it doesn't look like there was a strong reason to emit the warning in addition to printing a line to the console, so I've just removed it.

This is particularly useful for projects (like most of mine) which enable both warnings-as-errors and require 100% coverage as pytest defaults; in the current version I can't actually use `--no-cov` at all and that's rather unfortunate when I want to experiment with mutation testing.