### PR TITLE
Implement better --no-cov warning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ setup(
         'cover', 'coverage', 'pytest', 'py.test', 'distributed', 'parallel',
     ],
     install_requires=[
-        'pytest>=3.6',
+        'pytest>=4.6',
         'coverage>=4.4'
     ],
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',

--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -9,8 +9,6 @@ import pytest
 from . import compat
 from . import embed
 
-PYTEST_VERSION = tuple(map(int, pytest.__version__.split('.')[:3]))
-
 
 class CoverageError(Exception):
     """Indicates that our coverage is too low"""
@@ -114,8 +112,17 @@ def _prepare_cov_source(cov_source):
 
 @pytest.mark.tryfirst
 def pytest_load_initial_conftests(early_config, parser, args):
+    options = early_config.known_args_namespace
+    no_cov = options.no_cov_should_warn = False
+    for arg in args:
+        if arg == '--no-cov':
+            no_cov = True
+        elif arg.startswith('--cov') and no_cov:
+            options.no_cov_should_warn = True
+            break
+
     if early_config.known_args_namespace.cov_source:
-        plugin = CovPlugin(early_config.known_args_namespace, early_config.pluginmanager)
+        plugin = CovPlugin(options, early_config.pluginmanager)
         early_config.pluginmanager.register(plugin, '_cov')
 
 
@@ -127,7 +134,7 @@ class CovPlugin(object):
     distributed worker.
     """
 
-    def __init__(self, options, pluginmanager, start=True):
+    def __init__(self, options, pluginmanager, start=True, no_cov_should_warn=False):
         """Creates a coverage pytest plugin.
 
         We read the rc file that coverage uses to get the data file
@@ -275,10 +282,7 @@ class CovPlugin(object):
                 message = 'Failed to generate report: %s\n' % exc
                 session.config.pluginmanager.getplugin("terminalreporter").write(
                     'WARNING: %s\n' % message, red=True, bold=True)
-                if PYTEST_VERSION >= (3, 8):
-                    warnings.warn(pytest.PytestWarning(message))
-                else:
-                    session.config.warn(code='COV-2', message=message)
+                warnings.warn(pytest.PytestWarning(message))
                 self.cov_total = 0
             assert self.cov_total is not None, 'Test coverage should never be `None`'
             if self._failed_cov_total():
@@ -287,12 +291,10 @@ class CovPlugin(object):
 
     def pytest_terminal_summary(self, terminalreporter):
         if self._disabled:
-            message = 'Coverage disabled via --no-cov switch!'
-            terminalreporter.write('WARNING: %s\n' % message, red=True, bold=True)
-            if PYTEST_VERSION >= (3, 8):
+            if self.options.no_cov_should_warn:
+                message = 'Coverage disabled via --no-cov switch!'
+                terminalreporter.write('WARNING: %s\n' % message, red=True, bold=True)
                 warnings.warn(pytest.PytestWarning(message))
-            else:
-                terminalreporter.config.warn(code='COV-1', message=message)
             return
         if self.cov_controller is None:
             return

--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -666,13 +666,15 @@ def test_fail():
     result.stdout.fnmatch_lines(['*1 failed*'])
 
 
-def test_no_cov(testdir):
+def test_no_cov(testdir, monkeypatch):
     script = testdir.makepyfile(SCRIPT)
-
+    testdir.makeini("""
+        [pytest]
+        addopts=--no-cov
+    """)
     result = testdir.runpytest('-vvv',
                                '--cov=%s' % script.dirpath(),
                                '--cov-report=term-missing',
-                               '--no-cov',
                                '-rw',
                                script)
     result.stdout.fnmatch_lines_random([
@@ -2009,8 +2011,9 @@ def test_cov_and_no_cov(testdir):
     result = testdir.runpytest('-v',
                                '--cov', '--no-cov',
                                '-n', '1',
+                               '-s',
                                script)
-
+    result.stdout.no_fnmatch_line('*Coverage disabled via --no-cov switch!*')
     assert result.ret == 0
 
 

--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -2013,7 +2013,8 @@ def test_cov_and_no_cov(testdir):
                                '-n', '1',
                                '-s',
                                script)
-    result.stdout.no_fnmatch_line('*Coverage disabled via --no-cov switch!*')
+    assert 'Coverage disabled via --no-cov switch!' not in result.stdout.str()
+    assert 'Coverage disabled via --no-cov switch!' not in result.stderr.str()
     assert result.ret == 0
 
 


### PR DESCRIPTION
Only do it if --no-cov is present before --cov. Also remove some legacy pytest support and bump min version in setup.py. Closes #407. Ref #304.