### PR TITLE
Use "worker" for compatibility with xdist >= 2.0

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -38,3 +38,4 @@ Authors
 * Hugo van Kemenade - https://github.com/hugovk
 * Michael Manganiello - https://github.com/adamantike
 * Anders Hovmöller - https://github.com/boxed
+* Zac Hatfield-Dodds - https://zhd.dev

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+2.10.1 (2020-06-??)
+-------------------
+
+* Support for ``pytest-xdist`` 2.0, which breaks compatibility with ``pytest-xdist`` before 1.22.3 (from 2017).
+  Contributed by Zac Hatfield-Dodds in `#412 <https://github.com/pytest-dev/pytest-cov/pull/412>`_.
+
 2.10.0 (2020-06-12)
 -------------------
 

--- a/src/pytest_cov/compat.py
+++ b/src/pytest_cov/compat.py
@@ -29,22 +29,3 @@ class SessionWrapper(object):
     @testsfailed.setter
     def testsfailed(self, value):
         setattr(self._session, self._attr, value)
-
-
-def _attrgetter(attr):
-    """
-    Return a callable object that fetches attr from its operand.
-
-    Unlike operator.attrgetter, the returned callable supports an extra two
-    arg form for a default.
-    """
-    def fn(obj, *args):
-        return getattr(obj, attr, *args)
-
-    return fn
-
-
-worker = 'slave'  # for compatability with pytest-xdist<=1.22.0
-workerid = worker + 'id'
-workerinput = _attrgetter(worker + 'input')
-workeroutput = _attrgetter(worker + 'output')

--- a/src/pytest_cov/engine.py
+++ b/src/pytest_cov/engine.py
@@ -11,8 +11,6 @@ import coverage
 from coverage.data import CoverageData
 
 from .compat import StringIO
-from .compat import workerinput
-from .compat import workeroutput
 from .embed import cleanup
 
 
@@ -271,7 +269,7 @@ class DistMaster(CovController):
     def configure_node(self, node):
         """Workers need to know if they are collocated and what files have moved."""
 
-        workerinput(node).update({
+        node.workerinput.update({
             'cov_master_host': socket.gethostname(),
             'cov_master_topdir': self.topdir,
             'cov_master_rsync_roots': [str(root) for root in node.nodemanager.roots],
@@ -282,7 +280,7 @@ class DistMaster(CovController):
 
         # If worker doesn't return any data then it is likely that this
         # plugin didn't get activated on the worker side.
-        output = workeroutput(node, {})
+        output = getattr(node, 'workeroutput', {})
         if 'cov_worker_node_id' not in output:
             self.failed_workers.append(node)
             return
@@ -341,12 +339,12 @@ class DistWorker(CovController):
         cleanup()
 
         # Determine whether we are collocated with master.
-        self.is_collocated = (socket.gethostname() == workerinput(self.config)['cov_master_host'] and
-                              self.topdir == workerinput(self.config)['cov_master_topdir'])
+        self.is_collocated = (socket.gethostname() == self.config.workerinput['cov_master_host'] and
+                              self.topdir == self.config.workerinput['cov_master_topdir'])
 
         # If we are not collocated then rewrite master paths to worker paths.
         if not self.is_collocated:
-            master_topdir = workerinput(self.config)['cov_master_topdir']
+            master_topdir = self.config.workerinput['cov_master_topdir']
             worker_topdir = self.topdir
             if self.cov_source is not None:
                 self.cov_source = [source.replace(master_topdir, worker_topdir)
@@ -375,7 +373,7 @@ class DistWorker(CovController):
 
             # If we are collocated then just inform the master of our
             # data file to indicate that we have finished.
-            workeroutput(self.config)['cov_worker_node_id'] = self.nodeid
+            self.config.workeroutput['cov_worker_node_id'] = self.nodeid
         else:
             self.cov.combine()
             self.cov.save()
@@ -391,7 +389,7 @@ class DistWorker(CovController):
             else:
                 data = self.cov.get_data().dumps()
 
-            workeroutput(self.config).update({
+            self.config.workeroutput.update({
                 'cov_worker_path': self.topdir,
                 'cov_worker_node_id': self.nodeid,
                 'cov_worker_data': data,

--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -203,7 +203,7 @@ class CovPlugin(object):
             self.options.cov_fail_under = cov_config.fail_under
 
     def _is_worker(self, session):
-        return compat.workerinput(session.config, None) is not None
+        return getattr(session.config, 'workerinput', None) is not None
 
     def pytest_sessionstart(self, session):
         """At session start determine our implementation and delegate to it."""
@@ -220,8 +220,7 @@ class CovPlugin(object):
         self.pid = os.getpid()
         if self._is_worker(session):
             nodeid = (
-                compat.workerinput(session.config)
-                .get(compat.workerid, getattr(session, 'nodeid'))
+                session.config.workerinput.get('workerid', getattr(session, 'nodeid'))
             )
             self.start(engine.DistWorker, session.config, nodeid)
         elif not self._started:

--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -19,7 +19,6 @@ from process_tests import wait_for_strings
 from six import exec_
 
 import pytest_cov.plugin
-from pytest_cov import compat
 
 try:
     from StringIO import StringIO
@@ -28,7 +27,7 @@ except ImportError:
 
 coverage, platform      # required for skipif mark on test_cov_min_from_coveragerc
 
-max_worker_restart_0 = "--max-" + compat.worker + "-restart=0"
+max_worker_restart_0 = "--max-worker-restart=0"
 
 SCRIPT = '''
 import sys, helper


### PR DESCRIPTION
Fixes #411, at cost of support for xdist 1.22 and earlier from 2017.  Given that such old versions aren't even in our test matrix, I figured that this would be OK.