### PR TITLE
Python 2 has not been dropped yet

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -130,7 +130,7 @@ Changelog
 2.6.0 (2018-09-03)
 ------------------
 
-* Dropped support for Python < 3.4, Pytest < 3.5 and Coverage < 4.4.
+* Dropped support for Python 3 < 3.4, Pytest < 3.5 and Coverage < 4.4.
 * Fixed some documentation formatting. Contributed by Jean Jordaan and Julian.
 * Added an example with ``addopts`` in documentation. Contributed by Samuel Giffard in
   `#195 <https://github.com/pytest-dev/pytest-cov/pull/195>`_.


### PR DESCRIPTION
Python < 3.4 was not dropped in 2.6.0, as Python 2.7 is still supported. Fix this changelog typo to make things clear