### PR TITLE
Update config.rst wrt ignored .coveragerc settings

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -21,9 +21,16 @@ For full details refer to the `coverage config file`_ documentation.
 
 .. _`coverage config file`: https://coverage.readthedocs.io/en/latest/config.html
 
-**Important Note :** This plugin controls some options and setting the option in the config file will have no
-effect.  These include specifying source to be measured ("source" option) and all data file handling
-("data_file" and "parallel" options).
+.. note:: Important Note
+
+    This plugin overrides the ``data_file`` and ``parallel`` options of coverage. Unless you also run coverage without 
+    pytest-cov it's pointless to set those options in your ``.coveragerc``.
+    
+    If you use the ``--cov=something`` option (with a value) then coverage's ``source`` option will also get overriden. 
+    If you have multiple sources it might be easier to set those in ``.coveragerc`` and always use ``--cov`` (wihout a value) 
+    instead of having a long command line with ``--cov=pkg1 --cov=pkg2 --cov=pkg3 ...``.
+    
+    If you use the ``--cov-branch`` option then coverage's ``branch`` option will also get overriden.
 
 If you wish to always add pytest-cov with pytest, you can use ``addopts`` under ``pytest`` or ``tool:pytest`` section.
 For example: ::

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -21,9 +21,9 @@ For full details refer to the `coverage config file`_ documentation.
 
 .. _`coverage config file`: https://coverage.readthedocs.io/en/latest/config.html
 
-Note that this plugin controls some options and setting the option in the config file will have no
-effect.  These include specifying source to be measured (source option) and all data file handling
-(data_file and parallel options).
+**Important Note :** This plugin controls some options and setting the option in the config file will have no
+effect.  These include specifying source to be measured ("source" option) and all data file handling
+("data_file" and "parallel" options).
 
 If you wish to always add pytest-cov with pytest, you can use ``addopts`` under ``pytest`` or ``tool:pytest`` section.
 For example: ::


### PR DESCRIPTION
I took a while to figure out why coverage wasn't working correctly for our large project until yesterday, when I read the paragraph that called out the `.coveragerc` options that `pytest-cov` ignores.  

This PR makes that part of the documentation "pop" a bit more.

I considered moving it under "Caveats", but decided that that would mean rewriting "Caveats" to have two separate issues, rather than the one that it currently explains.