### PR TITLE
Bumped coverage to 5.2.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ setup(
     ],
     install_requires=[
         'pytest>=4.6',
-        'coverage>=4.4'
+        'coverage>=5.2.1'
     ],
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     extras_require={


### PR DESCRIPTION
Possible solution to issue #409. Code coverage report included lines that don't exist on python 3.8.5 and coverage 4.4. Example repo [NovaAPI](https://github.com/novaweb-mobi/nova-api). Updating coverage solved the issue.

fixes #409