### PR TITLE
Do not install empty console_scripts entry point

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -141,8 +141,6 @@ setup(
         'pytest11': [
             'pytest_cov = pytest_cov.plugin',
         ],
-        'console_scripts': [
-        ]
     },
     cmdclass={
         'build': BuildWithPTH,


### PR DESCRIPTION
The empty 'console_scripts' entry point serves no purpose, and it is
rather unlikely for it to contain any script in the near future.  Its
presence confuses Gentoo missing dependency checks.