### PR TITLE
Change example configs to support tox -e pyXX

### DIFF
--- a/examples/adhoc-layout/tox.ini
+++ b/examples/adhoc-layout/tox.ini
@@ -1,12 +1,14 @@
 [tox]
-envlist = clean,py27,py38,report
+envlist = py27,py38,report
 
 [tool:pytest]
 addopts =
     --cov-report=term-missing
 
 [testenv]
-commands = pytest --cov --cov-append --cov-config={toxinidir}/.coveragerc {posargs:-vv}
+setenv =
+    py{27,38}: COVERAGE_FILE = .coverage.{envname}
+commands = pytest --cov --cov-config={toxinidir}/.coveragerc {posargs:-vv}
 deps =
     pytest
     coverage
@@ -17,7 +19,6 @@ deps =
     ../..
 
 depends =
-    {py27,py38}: clean
     report: py27,py38
 
 # note that this is necessary to prevent the tests importing the code from your badly laid project
@@ -27,10 +28,6 @@ changedir = tests
 skip_install = true
 deps = coverage
 commands =
+    coverage combine
     coverage html
     coverage report --fail-under=100
-
-[testenv:clean]
-skip_install = true
-deps = coverage
-commands = coverage erase

--- a/examples/src-layout/tox.ini
+++ b/examples/src-layout/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = clean,py27,py38,report
+envlist = py27,py38,report
 
 [tool:pytest]
 testpaths = tests
@@ -7,7 +7,9 @@ addopts =
     --cov-report=term-missing
 
 [testenv]
-commands = pytest --cov --cov-append {posargs:-vv}
+setenv =
+    py{27,38}: COVERAGE_FILE = .coverage.{envname}
+commands = pytest --cov {posargs:-vv}
 deps =
     pytest
     coverage
@@ -18,17 +20,12 @@ deps =
     ../..
 
 depends =
-    {py27,py38}: clean
     report: py27,py38
 
 [testenv:report]
 skip_install = true
 deps = coverage
 commands =
+    coverage combine
     coverage html
     coverage report --fail-under=100
-
-[testenv:clean]
-skip_install = true
-deps = coverage
-commands = coverage erase


### PR DESCRIPTION
`tox -e pyXX` does not run the envs that pyXX depends on [[src](https://tox.readthedocs.io/en/latest/config.html?highlight=depends#conf-depends)]. This means that with the current example configs, running `tox -e pyXX` will not run `coverage clean` and so `pytest-cov` data will be appended to the preexisting `.coverage` file.

IMO, appending to the existing coverage data is not the expected behavior when running a single test suite against one Python version.

In fact, the current behavior can even cause decreased coverage to go undetected. E.g.:
1.  The user runs `tox` and generates a `.coverage` file that reports 100% coverage.
1.  The user deletes a bunch of tests and then runs `tox -e py38`.

With the current example configs, `tox -e py38` will report 100% coverage despite coverage really being lower. The user would have to run `tox` in full to discover the decreased coverage.

Related: #416
