### PR TITLE
Document coverage envvars

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -24,7 +24,8 @@ For full details refer to the `coverage config file`_ documentation.
 .. note:: Important Note
 
     This plugin overrides the ``data_file`` and ``parallel`` options of coverage. Unless you also run coverage without
-    pytest-cov it's pointless to set those options in your ``.coveragerc``.
+    pytest-cov it's pointless to set those options in your ``.coveragerc``.  Instead, to override the ``data_file`` setting,
+    you may instead use the environment variable ``COVERAGE_FILE``.
 
     If you use the ``--cov=something`` option (with a value) then coverage's ``source`` option will also get overriden.
     If you have multiple sources it might be easier to set those in ``.coveragerc`` and always use ``--cov`` (wihout a value)

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -23,13 +23,13 @@ For full details refer to the `coverage config file`_ documentation.
 
 .. note:: Important Note
 
-    This plugin overrides the ``data_file`` and ``parallel`` options of coverage. Unless you also run coverage without 
+    This plugin overrides the ``data_file`` and ``parallel`` options of coverage. Unless you also run coverage without
     pytest-cov it's pointless to set those options in your ``.coveragerc``.
-    
-    If you use the ``--cov=something`` option (with a value) then coverage's ``source`` option will also get overriden. 
-    If you have multiple sources it might be easier to set those in ``.coveragerc`` and always use ``--cov`` (wihout a value) 
+
+    If you use the ``--cov=something`` option (with a value) then coverage's ``source`` option will also get overriden.
+    If you have multiple sources it might be easier to set those in ``.coveragerc`` and always use ``--cov`` (wihout a value)
     instead of having a long command line with ``--cov=pkg1 --cov=pkg2 --cov=pkg3 ...``.
-    
+
     If you use the ``--cov-branch`` option then coverage's ``branch`` option will also get overriden.
 
 If you wish to always add pytest-cov with pytest, you can use ``addopts`` under ``pytest`` or ``tool:pytest`` section.


### PR DESCRIPTION
After digging around in the configuration settings of `pytest-cov` and `coverage.py`, looking for a way to configure the output data filename, I came across the environment variable `COVERAGE_FILE`.

This variable is even being used in the tests of `pytest-cov`, but its use is never mentioned.

This PR does two things

 - It normalizes the whitespace in `config.rst` (it is the only file in the docs with superfluous whitespace)
 - It mentions the environment variable, so that future folks don't have to search for it like I did.