### PR TITLE
Inherit coverage context in subprocesses

### DIFF
--- a/src/pytest_cov/embed.py
+++ b/src/pytest_cov/embed.py
@@ -45,6 +45,7 @@ def init():
     cov_config = os.environ.get('COV_CORE_CONFIG')
     cov_datafile = os.environ.get('COV_CORE_DATAFILE')
     cov_branch = True if os.environ.get('COV_CORE_BRANCH') == 'enabled' else None
+    cov_context = os.environ.get('COV_CORE_CONTEXT')
 
     if cov_datafile:
         if _active_cov:
@@ -71,6 +72,8 @@ def init():
         )
         cov.load()
         cov.start()
+        if cov_context:
+            cov.switch_context(cov_context)
         cov._warn_no_data = False
         cov._warn_unimported_source = False
         return cov

--- a/src/pytest_cov/engine.py
+++ b/src/pytest_cov/engine.py
@@ -110,6 +110,7 @@ class CovController(object):
         os.environ.pop('COV_CORE_CONFIG', None)
         os.environ.pop('COV_CORE_DATAFILE', None)
         os.environ.pop('COV_CORE_BRANCH', None)
+        os.environ.pop('COV_CORE_CONTEXT', None)
 
     @staticmethod
     def get_node_desc(platform, version_info):

--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -356,6 +356,7 @@ class TestContextPlugin(object):
     def switch_context(self, item, when):
         context = "{item.nodeid}|{when}".format(item=item, when=when)
         self.cov.switch_context(context)
+        os.environ['COV_CORE_CONTEXT'] = context
 
 
 @pytest.fixture


### PR DESCRIPTION
At the moment subprocess calls are missing coverage context, this fixes that issue.

Resolves #442 

Signed-off-by: Bernát Gábor <bgabor8@bloomberg.net>