### PR TITLE
Fix custom setup.py commands with newer setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,24 +30,24 @@ def read(*names, **kwargs):
 
 
 class BuildWithPTH(build):
-    def run(self):
-        build.run(self)
+    def run(self, *args, **kwargs):
+        build.run(self, *args, **kwargs)
         path = join(dirname(__file__), 'src', 'pytest-cov.pth')
         dest = join(self.build_lib, basename(path))
         self.copy_file(path, dest)
 
 
 class EasyInstallWithPTH(easy_install):
-    def run(self):
-        easy_install.run(self)
+    def run(self, *args, **kwargs):
+        easy_install.run(self, *args, **kwargs)
         path = join(dirname(__file__), 'src', 'pytest-cov.pth')
         dest = join(self.install_dir, basename(path))
         self.copy_file(path, dest)
 
 
 class InstallLibWithPTH(install_lib):
-    def run(self):
-        install_lib.run(self)
+    def run(self, *args, **kwargs):
+        install_lib.run(self, *args, **kwargs)
         path = join(dirname(__file__), 'src', 'pytest-cov.pth')
         dest = join(self.install_dir, basename(path))
         self.copy_file(path, dest)
@@ -58,8 +58,8 @@ class InstallLibWithPTH(install_lib):
 
 
 class DevelopWithPTH(develop):
-    def run(self):
-        develop.run(self)
+    def run(self, *args, **kwargs):
+        develop.run(self, *args, **kwargs)
         path = join(dirname(__file__), 'src', 'pytest-cov.pth')
         dest = join(self.install_dir, basename(path))
         self.copy_file(path, dest)


### PR DESCRIPTION
Fix custom commands to handle additional arguments to the run() method.
This is needed with newer versions of setuptools since they've started
passing 'show_deprecation' kwarg in easy_install command, and this
resulted in the following error:

```
Traceback (most recent call last):
  File "/tmp/pytest-cov/./setup.py", line 86, in <module>
    setup(
  File "/usr/lib/python3.9/site-packages/setuptools/__init__.py", line 153, in setup
    return distutils.core.setup(**attrs)
  File "/usr/lib/python3.9/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/usr/lib/python3.9/distutils/dist.py", line 966, in run_commands
    self.run_command(cmd)
  File "/usr/lib/python3.9/distutils/dist.py", line 985, in run_command
    cmd_obj.run()
  File "/usr/lib/python3.9/site-packages/setuptools/command/install.py", line 67, in run
    self.do_egg_install()
  File "/usr/lib/python3.9/site-packages/setuptools/command/install.py", line 117, in do_egg_install
    cmd.run(show_deprecation=False)
TypeError: run() got an unexpected keyword argument 'show_deprecation'
```

While at it, future-proof all overriden commands to accept pass any
arguments through.