### PR TITLE
Implement --cov-reset option that resets accumulated --cov directorie…

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -66,6 +66,8 @@ The complete list of command line options is:
                         False
   --no-cov              Disable coverage report completely (useful for
                         debuggers). Default: False
+  --cov-reset           Reset cov sources accumulated in options so far.
+                        Mostly useful for scripts and configuration files.
   --cov-fail-under=MIN  Fail if the total coverage is less than MIN.
   --cov-append          Do not delete coverage but append to current. Default:
                         False

--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -70,6 +70,8 @@ def pytest_addoption(parser):
                     nargs='?', const=True, dest='cov_source',
                     help='Path or package name to measure during execution (multi-allowed). '
                          'Use --cov= to not do any source filtering and record everything.')
+    group.addoption('--cov-reset', action='store_const', const=[], dest='cov_source',
+                    help='Reset cov sources accumulated in options so far. ')
     group.addoption('--cov-report', action=StoreReport, default={},
                     metavar='TYPE', type=validate_report,
                     help='Type of report to generate: term, term-missing, '

--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -1999,6 +1999,33 @@ def test_double_cov2(testdir):
     assert result.ret == 0
 
 
+def test_cov_reset(testdir):
+    script = testdir.makepyfile(SCRIPT_SIMPLE)
+    result = testdir.runpytest('-v',
+                               '--assert=plain',
+                               '--cov=%s' % script.dirpath(),
+                               '--cov-reset',
+                               script)
+
+    assert 'coverage: platform' not in result.stdout.str()
+
+
+def test_cov_reset_then_set(testdir):
+    script = testdir.makepyfile(SCRIPT_SIMPLE)
+    result = testdir.runpytest('-v',
+                               '--assert=plain',
+                               '--cov=%s' % script.dirpath(),
+                               '--cov-reset',
+                               '--cov=%s' % script.dirpath(),
+                               script)
+
+    result.stdout.fnmatch_lines([
+        '*- coverage: platform *, python * -*',
+        'test_cov_reset_then_set* %s*' % SCRIPT_SIMPLE_RESULT,
+        '*1 passed*'
+    ])
+
+
 @pytest.mark.skipif('sys.platform == "win32" and platform.python_implementation() == "PyPy"')
 def test_cov_and_no_cov(testdir):
     script = testdir.makepyfile(SCRIPT_SIMPLE)


### PR DESCRIPTION
Implement --cov-reset option that resets accumulated --cov directories.

Don't seem to be able to link to an issue, so here it is: https://github.com/pytest-dev/pytest-cov/issues/460

FWIW, the tests here are the integration tests in line with the rest of them, though we could arguably have a simple (and much faster) unit test that just checks if the options are modified correctly.