### PR TITLE
change license in setup.py from BSD to MIT to match LICENSE file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'Framework :: Pytest',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
+        'License :: OSI Approved :: MIT License',
         'Operating System :: Microsoft :: Windows',
         'Operating System :: POSIX',
         'Operating System :: Unix',


### PR DESCRIPTION
License listed in setup.py says BSD while LICENSE file says MIT.
This led some tools  for license check to incorrectly state that the license for pytest-cov is BSD.
Changing setup.py license from BSD to MIT to correct this.