### PR TITLE
Avoid using toml as extra

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,8 @@ setup(
     ],
     install_requires=[
         'pytest>=4.6',
-        'coverage[toml]>=5.2.1'
+        'coverage>=5.2.1',
+        'toml'
     ],
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     extras_require={


### PR DESCRIPTION
Avoid pip-compile bug which forces it to produce invalid constraints files. Installing toml as a direct dependency is enough to avoid this bug as fixing it in pip-compile is far from an easy task.

Declaring dependencies using extras is a extremely uncommon in python packages and as far as I know this is the only mainstream package that does that, and is is very easy to avoid. If we not fixing this we prevent users from creating constraints for their test requirements, something very useful as nobody likes getting its CI broken due to some test tool being updated an hour ago.

Related: https://github.com/jazzband/pip-tools/issues/1300