### PR TITLE
Revert "Avoid using toml as extra"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -124,8 +124,7 @@ setup(
     ],
     install_requires=[
         'pytest>=4.6',
-        'coverage>=5.2.1',
-        'toml'
+        'coverage[toml]>=5.2.1'
     ],
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     extras_require={


### PR DESCRIPTION
Reverts pytest-dev/pytest-cov#472

This is to achieve compatibility with `coverage` versions >5.5 where `toml` dependency [has changed](https://github.com/nedbat/coveragepy/pull/1186).

@ssbarnea I presume that https://github.com/pytest-dev/pytest-cov/pull/472 should be safe to revert now that the linked pip-tools [issue](https://github.com/jazzband/pip-tools/issues/1300) has been closed? Is that correct?
