### PR TITLE
Revert "Avoid using toml as extra (#472)"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -124,8 +124,7 @@ setup(
     ],
     install_requires=[
         'pytest>=4.6',
-        'coverage>=5.2.1',
-        'toml'
+        'coverage[toml]>=5.2.1'
     ],
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     extras_require={


### PR DESCRIPTION
This reverts commit 34edfa1cf80f8d722dec4f587b10d2783f89a0f0.

coverage[toml] now depends on `tomli`: https://github.com/nedbat/coveragepy/blob/c0da97eb03d4ffe8be8854ad6ff1a2736f169003/setup.py#L110

and this is fixed now https://github.com/jazzband/pip-tools/issues/1300

so I think the work-around should be removed