### PR TITLE
Fix typo in contexts.rst

### DIFF
--- a/docs/contexts.rst
+++ b/docs/contexts.rst
@@ -6,7 +6,7 @@ Coverage.py 5.0 can record separate coverage data for `different contexts`_ duri
 one run of a test suite.  Pytest-cov can use this feature to record coverage
 data for each test individually, with the ``--cov-context=test`` option.
 
-.. _`different_contexts`: https://coverage.readthedocs.io/en/stable/contexts.html
+.. _different contexts: https://coverage.readthedocs.io/en/stable/contexts.html
 
 The context name recorded in the coverage.py database is the pytest test id,
 and the phase of execution, one of "setup", "run", or "teardown".  These two


### PR DESCRIPTION
The hyperlink wasn't rendering properly. This looks better.