### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy-3.6", "pypy-3.7", "3.6", "3.7", "3.8", "3.9"]
+        python-version: ["pypy-3.6", "pypy-3.7", "3.6", "3.7", "3.8", "3.9", "3.10-dev"]
         tox-extra-versions: [
             "pytest46-xdist127",
             "pytest46-xdist133",
@@ -26,12 +26,16 @@ jobs:
           - {python-version: "3.7", tox-python-version: "py37"}
           - {python-version: "3.8", tox-python-version: "py38"}
           - {python-version: "3.9", tox-python-version: "py39"}
+          - {python-version: "3.10-dev", tox-python-version: "py310"}
         exclude:
           # Remove some jobs from the matrix
           - {tox-extra-versions: "pytest46-xdist127", python-version: "3.8"}
           - {tox-extra-versions: "pytest46-xdist127", python-version: "3.9"}
           - {tox-extra-versions: "pytest46-xdist133", python-version: "3.9"}
           - {tox-extra-versions: "pytest54-xdist133", python-version: "3.9"}
+          - {tox-extra-versions: "pytest46-xdist127", python-version: "3.10-dev"}
+          - {tox-extra-versions: "pytest46-xdist133", python-version: "3.10-dev"}
+          - {tox-extra-versions: "pytest54-xdist133", python-version: "3.10-dev"}
 
     steps:
       - uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal = 1
-
 [flake8]
 max-line-length = 140
 exclude = .tox,.eggs,ci/templates,build,dist

--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Testing',

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ envlist =
     check
     py{36,37,py,py3}-pytest46-xdist127-coverage{55}
     py{36,37,38,py3}-pytest{46,54}-xdist133-coverage{55}
-    py{36,37,38,39,py3}-pytest{62}-xdist202-coverage{55}
+    py{36,37,38,39,310,py3}-pytest{62}-xdist202-coverage{55}
     docs
 
 [testenv]
@@ -29,7 +29,7 @@ setenv =
     pytest54:  _DEP_PYTEST=pytest==5.4.3
     pytest60:  _DEP_PYTEST=pytest==6.0.2
     pytest61:  _DEP_PYTEST=pytest==6.1.2
-    pytest62:  _DEP_PYTEST=pytest==6.2.2
+    pytest62:  _DEP_PYTEST=pytest==6.2.5
 
     xdist127: _DEP_PYTESTXDIST=pytest-xdist==1.27.0
     xdist129: _DEP_PYTESTXDIST=pytest-xdist==1.29.0


### PR DESCRIPTION
Ahead of tomorrow's release party! https://twitter.com/pyblogsal/status/1442890650303664131

Bumps the pinned version of pytest 6.2, needed to support Python 3.10.

Also no need to build universal wheels for Python 3-only.
