### PR TITLE
`--cov-fail-under` should not cause `pytest --collect-only` to fail

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -50,3 +50,4 @@ Authors
 * Brian Rutledge - https://github.com/bhrutledge
 * Danilo Šegan - https://github.com/dsegan
 * Michał Bielawski - https://github.com/D3X
+* Zac Hatfield-Dodds - https://github.com/Zac-HD

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@ Changelog
 =========
 
 
+3.1.0 (future)
+-------------------
+
+* `--cov-fail-under` no longer causes `pytest --collect-only` to fail
+  Contributed by Zac Hatfield-Dodds in
+  `#511 <https://github.com/pytest-dev/pytest-cov/pull/511>`_.
+
+
 3.0.0 (2021-10-04)
 -------------------
 

--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -308,7 +308,7 @@ class CovPlugin:
                 warnings.warn(CovReportWarning(message))
                 self.cov_total = 0
             assert self.cov_total is not None, 'Test coverage should never be `None`'
-            if self._failed_cov_total():
+            if self._failed_cov_total() and not self.options.collectonly:
                 # make sure we get the EXIT_TESTSFAILED exit code
                 compat_session.testsfailed += 1
 

--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -389,6 +389,19 @@ def test_cov_min_100(testdir):
     ])
 
 
+def test_cov_min_100_passes_if_collectonly(testdir):
+    script = testdir.makepyfile(SCRIPT)
+
+    result = testdir.runpytest('-v',
+                               '--cov=%s' % script.dirpath(),
+                               '--cov-report=term-missing',
+                               '--cov-fail-under=100',
+                               '--collect-only',
+                               script)
+
+    assert result.ret == 0
+
+
 def test_cov_min_50(testdir):
     script = testdir.makepyfile(SCRIPT)
 


### PR DESCRIPTION
I often have `--cov-fail-under=100` set from a config file, because I expect full coverage from running my tests.

With [HypoFuzz](https://pypi.org/project/hypofuzz/), however, I use `pytest --collect-only` to collect the tests and then run them with the fuzzer... but `--cov-fail-under` returns an error because collection didn't reach 100% coverage!  That seems pretty silly, so this patch makes us skip the coverage check if pytest is running in `--collect-only` mode.  Fixes #426. 

(I can `hypothesis fuzz -- --cov-fail-under=0` for now, but that's a pretty inelegant workaround which I'd rather not require of my users)