### PR TITLE
Update test_invalid_coverage_source for coverage-6.2

### DIFF
--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -981,7 +981,7 @@ def test_invalid_coverage_source(testdir):
         '*10 passed*'
     ])
     result.stderr.fnmatch_lines([
-        'Coverage.py warning: No data was collected.*'
+        '*No data was collected.*'
     ])
     result.stdout.fnmatch_lines([
         '*Failed to generate report: No data to report.',


### PR DESCRIPTION
Update test_invalid_coverage_source to make the "No data was collected"
less strict, as the output has changed in coverage-6.2.  This solution
was suggested by Tom Callaway (@spotrh) on the linked bug.

Fixes #509