### PR TITLE
Add sample error a user might encounter

### DIFF
--- a/docs/debuggers.rst
+++ b/docs/debuggers.rst
@@ -7,7 +7,13 @@ Debuggers and PyCharm
 When it comes to TDD one obviously would like to debug tests. Debuggers in Python use mostly the sys.settrace function
 to gain access to context. Coverage uses the same technique to get access to the lines executed. Coverage does not play
 well with other tracers simultaneously running. This manifests itself in behaviour that PyCharm might not hit a
-breakpoint no matter what the user does. Since it is common practice to have coverage configuration in the pytest.ini
+breakpoint no matter what the user does, or encountering an error like this::
+
+    PYDEV DEBUGGER WARNING:
+    sys.settrace() should not be used when the debugger is being used.
+    This may cause the debugger to stop working correctly.
+
+Since it is common practice to have coverage configuration in the pytest.ini
 file and pytest does not support removeopts or similar the `--no-cov` flag can disable coverage completely.
 
 At the reporting part a warning message will show on screen::


### PR DESCRIPTION
This PR adds a specific error message a user might encounter when debugging tests with code coverage enabled.

I experienced this issue today and unfortunately could not easily locate this documentation page.  I had to follow many different breadcrumb trails to get here.  Hopefully by adding this to the documentation future developers can more easily locate this documentation, understand the problem, and use the `--no-cov` flag to avoid it.