### PR TITLE
Prevent undesirable new lines to be displayed when report is disabled

### DIFF
--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -326,7 +326,11 @@ class CovPlugin:
             # we shouldn't report, or report generation failed (error raised above)
             return
 
-        terminalreporter.write('\n' + self.cov_report.getvalue() + '\n')
+        report = self.cov_report.getvalue()
+
+        # Avoid undesirable new lines when output is disabled with "--cov-report=".
+        if report:
+            terminalreporter.write('\n' + report + '\n')
 
         if self.options.cov_fail_under is not None and self.options.cov_fail_under > 0:
             failed = self.cov_total < self.options.cov_fail_under


### PR DESCRIPTION
Hi!

This is just a small tweak so that report displayed when `--cov-report=` matches the default `pytest` output. Otherwise, undesirable newlines are added while the output is empty anyway.

Before:

```
============================================================================== test session starts ==============================================================================
platform linux -- Python 3.10.5, pytest-7.1.2, pluggy-1.0.0
rootdir: /home/delgan/Programmation/loguru, configfile: tox.ini
plugins: cov-3.0.0, mypy-plugins-1.9.3
collected 1425 items / 1424 deselected / 1 selected                                                                                                                             

tests/test_levels.py .                                                                                                                                                    [100%]



====================================================================== 1 passed, 1424 deselected in 2.19s =======================================================================
```

After:

```
============================================================================== test session starts ==============================================================================
platform linux -- Python 3.10.5, pytest-7.1.2, pluggy-1.0.0
rootdir: /home/delgan/Programmation/loguru, configfile: tox.ini
plugins: cov-3.0.0, mypy-plugins-1.9.3
collected 1425 items / 1424 deselected / 1 selected                                                                                                                             

tests/test_levels.py .                                                                                                                                                    [100%]

====================================================================== 1 passed, 1424 deselected in 2.15s =======================================================================
```