### PR TITLE
migrate build command from distutils to setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import re
-from distutils.command.build import build
 from glob import glob
 from itertools import chain
 from os.path import basename
@@ -12,6 +11,11 @@ from os.path import splitext
 from setuptools import Command
 from setuptools import find_packages
 from setuptools import setup
+try:
+    # https://setuptools.pypa.io/en/latest/deprecated/distutils-legacy.html
+    from setuptools.command.build import build
+except ImportError:
+    from distutils.command.build import build
 from setuptools.command.develop import develop
 from setuptools.command.easy_install import easy_install
 from setuptools.command.install_lib import install_lib


### PR DESCRIPTION
Importing distutils before setuptools can (depending on the precendence of the current import search path) create problems:

```
[   19s] + cd pytest-cov-3.0.0
[   19s] + /usr/bin/python3.8 setup.py build '--executable=/usr/bin/python3.8 -s'
[   19s] /usr/lib/python3.8/site-packages/_distutils_hack/__init__.py:18: UserWarning: Distutils was imported before Setuptools, but importing Setuptools also replaces the `distutils` module in `sys.modules`. This may lead to undesirable behaviors or errors. To avoid these issues, avoid using distutils directly, ensure that setuptools is installed in the traditional way (e.g. not an editable install), and/or make sure that setuptools is always imported before distutils.
[   19s]   warnings.warn(
[   19s] /usr/lib/python3.8/site-packages/_distutils_hack/__init__.py:33: UserWarning: Setuptools is replacing distutils.
[   19s]   warnings.warn("Setuptools is replacing distutils.")
[   19s] Traceback (most recent call last):
[   19s]   File "setup.py", line 82, in <module>
[   19s]     setup(
[   19s]   File "/usr/lib/python3.8/site-packages/setuptools/__init__.py", line 87, in setup
[   19s]     return distutils.core.setup(**attrs)
[   19s]   File "/usr/lib/python3.8/site-packages/setuptools/_distutils/core.py", line 164, in setup
[   19s]     ok = dist.parse_command_line()
[   19s]   File "/usr/lib/python3.8/site-packages/setuptools/_distutils/dist.py", line 474, in parse_command_line
[   19s]     args = self._parse_command_opts(parser, args)
[   19s]   File "/usr/lib/python3.8/site-packages/setuptools/dist.py", line 1107, in _parse_command_opts
[   19s]     nargs = _Distribution._parse_command_opts(self, parser, args)
[   19s]   File "/usr/lib/python3.8/site-packages/setuptools/_distutils/dist.py", line 540, in _parse_command_opts
[   19s]     raise DistutilsClassError(
[   19s] distutils.errors.DistutilsClassError: command class <class '__main__.BuildWithPTH'> must subclass Command
```

Fixing by using `setuptools.command.build` if available (setuptools 60) or importing after setuptools if not.