### PR TITLE
Use modern approach to specify hook options

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,8 @@ Changelog
     parallel = true
     sigterm = true
 
+* Use modern way to specify hook options to avoid deprecation warnings with pytest >=7.2.
+
 
 3.0.0 (2021-10-04)
 -------------------

--- a/src/pytest_cov/compat.py
+++ b/src/pytest_cov/compat.py
@@ -3,15 +3,8 @@ try:
 except ImportError:
     from io import StringIO
 
-import pytest
 
 StringIO  # pyflakes, this is for re-export
-
-
-if hasattr(pytest, 'hookimpl'):
-    hookwrapper = pytest.hookimpl(hookwrapper=True)
-else:
-    hookwrapper = pytest.mark.hookwrapper
 
 
 class SessionWrapper:

--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -133,7 +133,7 @@ def _prepare_cov_source(cov_source):
     return None if True in cov_source else [path for path in cov_source if path is not True]
 
 
-@pytest.mark.tryfirst
+@pytest.hookimpl(tryfirst=True)
 def pytest_load_initial_conftests(early_config, parser, args):
     options = early_config.known_args_namespace
     no_cov = options.no_cov_should_warn = False
@@ -253,6 +253,7 @@ class CovPlugin:
         if self.options.cov_context == 'test':
             session.config.pluginmanager.register(TestContextPlugin(self.cov_controller.cov), '_cov_contexts')
 
+    @pytest.hookimpl(optionalhook=True)
     def pytest_configure_node(self, node):
         """Delegate to our implementation.
 
@@ -260,8 +261,8 @@ class CovPlugin:
         """
         if not self._disabled:
             self.cov_controller.configure_node(node)
-    pytest_configure_node.optionalhook = True
 
+    @pytest.hookimpl(optionalhook=True)
     def pytest_testnodedown(self, node, error):
         """Delegate to our implementation.
 
@@ -269,7 +270,6 @@ class CovPlugin:
         """
         if not self._disabled:
             self.cov_controller.testnodedown(node, error)
-    pytest_testnodedown.optionalhook = True
 
     def _should_report(self):
         return not (self.failed and self.options.no_cov_on_fail)
@@ -280,7 +280,7 @@ class CovPlugin:
 
     # we need to wrap pytest_runtestloop. by the time pytest_sessionfinish
     # runs, it's too late to set testsfailed
-    @compat.hookwrapper
+    @pytest.hookimpl(hookwrapper=True)
     def pytest_runtestloop(self, session):
         yield
 
@@ -356,7 +356,7 @@ class CovPlugin:
     def pytest_runtest_teardown(self, item):
         embed.cleanup()
 
-    @compat.hookwrapper
+    @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_call(self, item):
         if (item.get_closest_marker('no_cover')
                 or 'no_cover' in getattr(item, 'fixturenames', ())):


### PR DESCRIPTION
The old way using marks is being deprecated in pytest 7.2:

https://github.com/pytest-dev/pytest/pull/9118