### PR TITLE
Enable `pytest-cov[toml]` akin to upstream `coverage[toml]`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -142,7 +142,9 @@ setup(
             'six',
             'pytest-xdist',
             'virtualenv',
-        ]
+        ],
+        # Enable pyproject.toml support.
+        'toml': ['coverage[toml]'],
     },
     entry_points={
         'pytest11': [


### PR DESCRIPTION
https://github.com/nedbat/coveragepy/issues/664 (+ later fixes)

Signed-off-by: Stavros Ntentos <133706+stdedos@users.noreply.github.com>