### PR TITLE
Revert "Enable `pytest-cov[toml]` akin to upstream `coverage[toml]`"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -142,9 +142,7 @@ setup(
             'six',
             'pytest-xdist',
             'virtualenv',
-        ],
-        # Enable pyproject.toml support.
-        'toml': ['coverage[toml]'],
+        ]
     },
     entry_points={
         'pytest11': [


### PR DESCRIPTION
Reverts pytest-dev/pytest-cov#553