### PR TITLE
disabling boxed test if version xdist newer than 2.5.0

### DIFF
--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -1555,7 +1555,8 @@ def test_foo():
 
 SCRIPT_SIMPLE_RESULT = '4 * 100%'
 
-
+@pytest.mark.skipif('tuple(map(int, xdist.__version__.split("."))) >= (2, 5, 0)',
+                    reason="--boxed option was removed in version 2.5.0")
 @pytest.mark.skipif('sys.platform == "win32"')
 def test_dist_boxed(testdir):
     script = testdir.makepyfile(SCRIPT_SIMPLE)

--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -1555,8 +1555,8 @@ def test_foo():
 
 SCRIPT_SIMPLE_RESULT = '4 * 100%'
 
-@pytest.mark.skipif('tuple(map(int, xdist.__version__.split("."))) >= (2, 5, 0)',
-                    reason="--boxed option was removed in version 2.5.0")
+@pytest.mark.skipif('tuple(map(int, xdist.__version__.split("."))) >= (3, 0, 2)',
+                    reason="--boxed option was removed in version 3.0.2")
 @pytest.mark.skipif('sys.platform == "win32"')
 def test_dist_boxed(testdir):
     script = testdir.makepyfile(SCRIPT_SIMPLE)


### PR DESCRIPTION
Newer version of xdist  (> 2.5.0) have removed the boxed option.

[xdist changelog](https://github.com/pytest-dev/pytest-xdist/blob/master/CHANGELOG.rst#pytest-xdist-250-2021-12-10)