### PR TITLE
perf: only call summary when the report will be used

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -57,3 +57,4 @@ Authors
 * Colin O'Dell - https://github.com/colinodell
 * Ronny Pfannschmidt - https://github.com/RonnyPfannschmidt
 * Christian Fetzer - https://github.com/fetzerch
+* Jonathan Stewmon = https://github.com/jstewmon

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@ Changelog
 =========
 
 
+4.0.1 (2023-03-27)
+------------------
+
+* Skip generating the in-memory coverage report when it will not be used. For example,
+  when ``--cov-report=''`` is used without ``--cov-fail-under``.
+
+
 4.0.0 (2022-09-28)
 ------------------
 

--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -275,7 +275,8 @@ class CovPlugin:
             self.cov_controller.testnodedown(node, error)
 
     def _should_report(self):
-        return not (self.failed and self.options.no_cov_on_fail)
+        needed = self.options.cov_report or self.options.cov_fail_under
+        return needed and not (self.failed and self.options.no_cov_on_fail)
 
     def _failed_cov_total(self):
         cov_fail_under = self.options.cov_fail_under


### PR DESCRIPTION
👋 I would like to propose a small change to the control flow which precludes generating the coverage report if it is not going to be used by the given pytest run in which it was generated (i.e. it is going to be combined with other reports later).

I didn't add any new tests yet because I don't see any observable difference from the perspective of the tests. If there's any suggestions on how to support this change with a test, I'm happy to add tests to verify the behavior.

Waaay back when #34 was merged, the control flow changed to always generate a coverage report, even if it isn't used.

On small code bases, or code bases that collect all of their coverage in one step, this is probably fine, but on large code bases, it can take minutes to generate the report.

When used in conjunction with pytest-xdist, generating the report only leverages 1 CPU, leaving the rest idle. For example: if if the coverage report takes 2 minutes to generate, `pytest -n 8` may complete in 5 minute, while `pytest -n 8 --cov` completes in 7 minutes, wasting 15 CPU minutes.

I have a private code base that runs its test suite across dozens of CI jobs, most of which use pytest-xdist to run tests in parallel. On average, running a test job with coverage enabled adds ~80 seconds. The aggregate cost of all the wasted CPU minutes has become significant. I'd like to optimize by generating an aggregate coverage report by combining all the .coverage files after all jobs have run.