### PR TITLE
Removing message formatting rounding

### DIFF
--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -341,7 +341,7 @@ class CovPlugin:
             markup = {'red': True, 'bold': True} if failed else {'green': True}
             message = (
                 '{fail}Required test coverage of {required}% {reached}. '
-                'Total coverage: {actual:.2f}%\n'
+                'Total coverage: {actual}%\n'
                 .format(
                     required=self.options.cov_fail_under,
                     actual=self.cov_total,


### PR DESCRIPTION
When defining a coverage threshold (88.45 for example) and the actual coverage is very close (88.449  for example) we will get a failure message. However, the message will be: "FAIL Required test coverage of 88.45% not reached. Total coverage: 88.45%" where it's wrong and confusing since we failed because it's under while it the message it presented as equal. The removing of the rounding will fix it.