### PR TITLE
remove stale dependency on deprecated six

### DIFF
--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -1,5 +1,4 @@
 virtualenv>=16.6.0
 pip>=19.1.1
 setuptools>=18.0.1
-six>=1.14.0
 tox

--- a/setup.py
+++ b/setup.py
@@ -138,7 +138,6 @@ setup(
             'fields',
             'hunter',
             'process-tests',
-            'six',
             'pytest-xdist',
             'virtualenv',
         ]


### PR DESCRIPTION
Hi,

I'm coming here from https://github.com/deschler/django-modeltranslation/issues/705 .

I think that projects should declare a dependecy on six only if they use it, but not just in case some other project may need it, otherwise it will stay forever. 

Most projects still using six today are abandonware anyway.

Greetings :-) 

https://wiki.debian.org/Python3-six-removal