### PR TITLE
remove rsyncdir usage since pytest-xdist has deprecated it

### DIFF
--- a/src/pytest_cov/engine.py
+++ b/src/pytest_cov/engine.py
@@ -265,12 +265,6 @@ class DistMaster(CovController):
     def start(self):
         cleanup()
 
-        # Ensure coverage rc file rsynced if appropriate.
-        if self.cov_config and os.path.exists(self.cov_config):
-            # rsyncdir is going away in pytest-xdist 4.0, already deprecated
-            if hasattr(self.config.option, 'rsyncdir'):
-                self.config.option.rsyncdir.append(self.cov_config)
-
         self.cov = coverage.Coverage(source=self.cov_source,
                                      branch=self.cov_branch,
                                      data_suffix=True,


### PR DESCRIPTION
This removes the usage of rsyncdir so that pytest-xdist does not raise a deprecation warning. Trying to get all warning in my projects to go away. 

Issue submitted a bit ago https://github.com/pytest-dev/pytest-cov/issues/621 and a older one too https://github.com/pytest-dev/pytest-cov/issues/557