### PR TITLE
Update tox example to properly track coverage

### DIFF
--- a/examples/src-layout/tox.ini
+++ b/examples/src-layout/tox.ini
@@ -21,6 +21,7 @@ deps =
 
 depends =
     report: pypy3,py39
+usedevelop=True
 
 [testenv:report]
 skip_install = true


### PR DESCRIPTION
If `usedevelop=True` is not set, coverage for `tox` tests show up as "0%" because `tox` runs the tests in a virtualenv. (See https://stackoverflow.com/questions/58696476/tox-0-coverage)