### PR TITLE
Fix or remove URLs that are causing docs tests to fail

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -2,15 +2,15 @@
 Authors
 =======
 
-* Marc Schlaich - http://www.schlamar.org
-* Rick van Hattem - http://wol.ph
+* Marc Schlaich
+* Rick van Hattem - https://w.wol.ph
 * Buck Evan - https://github.com/bukzor
-* Eric Larson - http://larsoner.com
-* Marc Abramowitz - http://marc-abramowitz.com
+* Eric Larson - https://larsoner.com
+* Marc Abramowitz
 * Thomas Kluyver - https://github.com/takluyver
-* Guillaume Ayoub - http://www.yabz.fr
+* Guillaume Ayoub - https://www.yabz.fr
 * Federico Ceratto - http://firelet.net
-* Josh Kalderimis - http://blog.cookiestack.com
+* Josh Kalderimis
 * Ionel Cristian Mărieș - https://blog.ionelmc.ro
 * Christian Ledermann - https://github.com/cleder
 * Alec Nikolas Reiter - https://github.com/justanr

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,7 +45,7 @@ Changelog
   Contributed by Andre Brisco in `#543 <https://github.com/pytest-dev/pytest-cov/pull/543>`_
   and Colin O'Dell in `#525 <https://github.com/pytest-dev/pytest-cov/pull/525>`_.
 * Added support for LCOV output format via `--cov-report=lcov`. Only works with coverage 6.3+.
-  Contributed by Christian Fetzer in `#536 <https://github.com/pytest-dev/pytest-cov/issues/536>`_.
+  Contributed by Christian Fetzer in `#536 <https://github.com/pytest-dev/pytest-cov/pull/536>`_.
 * Modernized pytest hook implementation.
   Contributed by Bruno Oliveira in `#549 <https://github.com/pytest-dev/pytest-cov/pull/549>`_
   and Ronny Pfannschmidt in `#550 <https://github.com/pytest-dev/pytest-cov/pull/550>`_.
@@ -116,7 +116,7 @@ Changelog
 * Removed the empty `console_scripts` entrypoint that confused some Gentoo build script.
   I didn't ask why it was so broken cause I didn't want to ruin my day.
   Contributed by Michał Górny in `#434 <https://github.com/pytest-dev/pytest-cov/pull/434>`_.
-* Fixed the missing `coverage context <https://coverage.readthedocs.io/en/stable/contexts.html>`_
+* Fixed the missing `coverage context <https://coverage.readthedocs.io/en/latest/contexts.html>`_
   when using subprocesses.
   Contributed by Bernát Gábor in `#443 <https://github.com/pytest-dev/pytest-cov/pull/443>`_.
 * Updated the config section in the docs.
@@ -145,7 +145,7 @@ Changelog
 * Made pytest startup faster when plugin not active by lazy-importing.
   Contributed by Anders Hovmöller in `#339 <https://github.com/pytest-dev/pytest-cov/pull/339>`_.
 * Various CI improvements.
-  Contributed by Daniel Hahler in `#363 <https://github.com/pytest-dev/pytest-cov/pull/>`_ and
+  Contributed by Daniel Hahler in `#363 <https://github.com/pytest-dev/pytest-cov/pull/363>`_ and
   `#364 <https://github.com/pytest-dev/pytest-cov/pull/364>`_.
 * Various Python support updates (drop EOL 3.4, test against 3.8 final).
   Contributed by Hugo van Kemenade in

--- a/README.rst
+++ b/README.rst
@@ -108,7 +108,7 @@ Would produce a report like::
 Documentation
 =============
 
-    http://pytest-cov.rtfd.org/
+    https://pytest-cov.readthedocs.io/en/latest/
 
 
 

--- a/docs/contexts.rst
+++ b/docs/contexts.rst
@@ -6,7 +6,7 @@ Coverage.py 5.0 can record separate coverage data for `different contexts`_ duri
 one run of a test suite.  Pytest-cov can use this feature to record coverage
 data for each test individually, with the ``--cov-context=test`` option.
 
-.. _different contexts: https://coverage.readthedocs.io/en/stable/contexts.html
+.. _different contexts: https://coverage.readthedocs.io/en/latest/contexts.html
 
 The context name recorded in the coverage.py database is the pytest test id,
 and the phase of execution, one of "setup", "run", or "teardown".  These two

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -10,7 +10,7 @@ The current way of dealing with this problem is using the append feature and man
 
     COV_CORE_SOURCE=src COV_CORE_CONFIG=.coveragerc COV_CORE_DATAFILE=.coverage.eager pytest --cov=src --cov-append
 
-Alternatively you can have this in ``tox.ini`` (if you're using `Tox <https://tox.readthedocs.io/en/latest/>`_ of course)::
+Alternatively you can have this in ``tox.ini`` (if you're using `Tox <https://tox.wiki/en/latest/>`_ of course)::
 
     [testenv]
     setenv =

--- a/docs/tox.rst
+++ b/docs/tox.rst
@@ -2,7 +2,7 @@
 Tox
 ===
 
-When using `tox <https://tox.readthedocs.io/>`_ you can have ultra-compact configuration - you can have all of it in
+When using `tox <https://tox.wiki/en/stable/>`_ you can have ultra-compact configuration - you can have all of it in
 ``tox.ini``::
 
     [tox]


### PR DESCRIPTION
Fix or remove URLs that are causing GitHub Actions `docs` tests to fail.

![Tests docs passing](https://github.com/pytest-dev/pytest-cov/assets/3709715/7e3223ed-29dc-4223-8f7a-4390d3e3e0f1)


@schlamar @msabramo @joshk Your reviews, please.