### PR TITLE
Add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# introduced f-strings
+76fb2a6cb2c4a4a788a5b62710848daf9c8fb7ce

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -15,6 +15,7 @@ include .bumpversion.cfg
 include .cookiecutterrc
 include .coveragerc
 include .editorconfig
+include .git-blame-ignore-revs
 include .pre-commit-config.yaml
 include .readthedocs.yml
 include pytest.ini


### PR DESCRIPTION
This makes GitHub (and other tools that support this file, or any Git client with `git config blame.ignoreRevsFile .git-blame-ignore-revs` set) ignore the large reformatting/automatic commits, to make blame inspection easier.