### PR TITLE
Use ruff for formatting too

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,14 +6,11 @@ exclude: '^(\.tox|ci/templates|\.bumpversion\.cfg)(/|$)'
 # Note the order is intentional to avoid multiple passes of the hooks
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.3
+    rev: v0.4.5
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix, --show-fixes, --unsafe-fixes]
-  - repo: https://github.com/psf/black
-    rev: 24.3.0
-    hooks:
-      - id: black
+      - id: ruff-format
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,5 @@ inline-quotes = "single"
 forced-separate = ["conftest"]
 force-single-line = true
 
-[tool.black]
-line-length = 140
-target-version = ["py38"]
-skip-string-normalization = true
+[tool.ruff.format]
+quote-style = "preserve"

--- a/src/pytest_cov/engine.py
+++ b/src/pytest_cov/engine.py
@@ -361,7 +361,6 @@ class DistWorker(CovController):
 
     @_ensure_topdir
     def start(self):
-
         cleanup()
 
         # Determine whether we are collocated with master.

--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -248,7 +248,6 @@ class CovPlugin:
         # worker is started in pytest hook
 
     def start(self, controller_cls, config=None, nodeid=None):
-
         if config is None:
             # fake config option for engine
             class Config:
@@ -339,7 +338,6 @@ class CovPlugin:
             self.cov_controller.finish()
 
         if not self._is_worker(session) and self._should_report():
-
             # import coverage lazily here to avoid importing
             # it for unit tests that don't need it
             from coverage.misc import CoverageException


### PR DESCRIPTION
Following up on `ruff` being added for linting in #610, this makes formatting also use `ruff` instead of Black.