### PR TITLE
Move testing extras to a requirements_test.txt file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -25,5 +25,6 @@ include CHANGELOG.rst
 include CONTRIBUTING.rst
 include LICENSE
 include README.rst
+include requirements_test.txt
 
 global-exclude *.py[cod] __pycache__/* *.so *.dylib

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,5 @@
+fields
+hunter
+process-tests
+pytest-xdist
+virtualenv

--- a/setup.py
+++ b/setup.py
@@ -129,15 +129,6 @@ setup(
         'pytest>=4.6',
         'coverage[toml]>=5.2.1',
     ],
-    extras_require={
-        'testing': [
-            'fields',
-            'hunter',
-            'process-tests',
-            'pytest-xdist',
-            'virtualenv',
-        ]
-    },
     entry_points={
         'pytest11': [
             'pytest_cov = pytest_cov.plugin',

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,6 @@ basepython =
     py311: {env:TOXPYTHON:python3.11}
     py312: {env:TOXPYTHON:python3.12}
     {bootstrap,clean,check,report,docs}: {env:TOXPYTHON:python3}
-extras = testing
 setenv =
     PYTHONPATH={toxinidir}/tests
     PYTHONUNBUFFERED=yes
@@ -89,6 +88,7 @@ deps =
     {env:_DEP_PYTEST:pytest}
     {env:_DEP_PYTESTXDIST:pytest-xdist}
     {env:_DEP_COVERAGE:coverage}
+    -r requirements_test.txt
 pip_pre = true
 commands =
     {posargs:pytest -vv}


### PR DESCRIPTION
Move the ``testing`` extras from the setup.py to their own requirements_test.txt file.

Please let me know if I'm missing some details; I've put this together rather quickly.

The rationale here is that the `extras` list was showing up in a poetry.lock file for a project at my company. This was because pytest-cov was part of the dev-dependencies in a pyproject.toml file.
Our vulnerability scanning tool is designed to skip development dependencies. However, it doesn't skip a development dependency if it appears in the extras list in the poetry.lock file. Edit: the previous line appears to be inaccurate - it is skipped if there are only dev dependencies in pyproject.toml. 

This is not a problem with pytest-cov per-se but perhaps the change is acceptable in any case and helps others potentially. Maybe this PR makes sense from the perspective that the test extras would never be used by downstream users, but otherwise please feel free to close it😅

Thanks for your time!