### PR TITLE
Improve Terminal Output Formatting in pytest-cov

### DIFF
--- a/src/pytest_cov/engine.py
+++ b/src/pytest_cov/engine.py
@@ -155,15 +155,15 @@ class CovController:
 
         # Output coverage section header.
         if len(self.node_descs) == 1:
-            self.sep(stream, '-', f"coverage: {''.join(self.node_descs)}")
+            self.sep(stream, '_', f"coverage: {''.join(self.node_descs)}")
         else:
-            self.sep(stream, '-', 'coverage')
+            self.sep(stream, '_', 'coverage')
             for node_desc in sorted(self.node_descs):
                 self.sep(stream, ' ', f'{node_desc}')
 
         # Report on any failed workers.
         if self.failed_workers:
-            self.sep(stream, '-', 'coverage: failed workers')
+            self.sep(stream, '_', 'coverage: failed workers')
             stream.write('The following workers failed to return coverage data, ensure that pytest-cov is installed on these workers.\n')
             for node in self.failed_workers:
                 stream.write(f'{node.gateway.id}\n')

--- a/src/pytest_cov/engine.py
+++ b/src/pytest_cov/engine.py
@@ -163,7 +163,7 @@ class CovController:
             # trailing space is not important at the end of the line.
             if len(line) + len(s.rstrip()) <= fullwidth:
                 line += s.rstrip()
-            line += '\n'
+            line += '\n\n'
             stream.write(line)
 
     @_ensure_topdir

--- a/src/pytest_cov/engine.py
+++ b/src/pytest_cov/engine.py
@@ -140,14 +140,6 @@ class CovController:
         # The Windows get_terminal_size may be bogus, let's sanify a bit.
         if width < 40:
             width = 80
-        # The goal is to have the line be as long as possible
-        # under the condition that len(line) <= fullwidth.
-        if sys.platform == 'win32':
-            # If we print in the last column on windows we are on a
-            # new line but there is no way to verify/neutralize this
-            # (we may not know the exact line width).
-            # So let's be defensive to avoid empty lines in the output.
-            width -= 1
         return width
 
     def sep(self, stream, s, txt):
@@ -155,6 +147,14 @@ class CovController:
             stream.sep(s, txt)
         else:
             fullwidth = self.get_width()
+            # The goal is to have the line be as long as possible
+            # under the condition that len(line) <= fullwidth.
+            if sys.platform == 'win32':
+                # If we print in the last column on windows we are on a
+                # new line but there is no way to verify/neutralize this
+                # (we may not know the exact line width).
+                # So let's be defensive to avoid empty lines in the output.
+                fullwidth -= 1
             N = max((fullwidth - len(txt) - 2) // (2 * len(s)), 1)
             fill = s * N
             line = f'{fill} {txt} {fill}'

--- a/src/pytest_cov/engine.py
+++ b/src/pytest_cov/engine.py
@@ -136,6 +136,7 @@ class CovController:
 
     @staticmethod
     def get_width():
+        # taken from https://github.com/pytest-dev/pytest/blob/33c7b05a/src/_pytest/_io/terminalwriter.py#L26
         width, _ = shutil.get_terminal_size(fallback=(80, 24))
         # The Windows get_terminal_size may be bogus, let's sanify a bit.
         if width < 40:
@@ -147,6 +148,7 @@ class CovController:
             stream.sep(s, txt)
         else:
             fullwidth = self.get_width()
+            # taken from https://github.com/pytest-dev/pytest/blob/33c7b05a/src/_pytest/_io/terminalwriter.py#L126
             # The goal is to have the line be as long as possible
             # under the condition that len(line) <= fullwidth.
             if sys.platform == 'win32':
@@ -163,6 +165,7 @@ class CovController:
             # trailing space is not important at the end of the line.
             if len(line) + len(s.rstrip()) <= fullwidth:
                 line += s.rstrip()
+            # (end of terminalwriter borrowed code)
             line += '\n\n'
             stream.write(line)
 

--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -379,10 +379,9 @@ class CovPlugin:
 
         report = self.cov_report.getvalue()
 
-        # Avoid undesirable new lines when output is disabled with "--cov-report=".
         if report:
             self.write_heading(terminalreporter)
-            terminalreporter.write('\n' + report + '\n')
+            terminalreporter.write(report)
 
         if self.options.cov_fail_under is not None and self.options.cov_fail_under > 0:
             self.write_heading(terminalreporter)

--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -333,6 +333,7 @@ class CovPlugin:
             # it for unit tests that don't need it
             from coverage.misc import CoverageException
 
+            self.cov_controller.sep(self.cov_report, '=', 'coverage report')
             try:
                 self.cov_total = self.cov_controller.summary(self.cov_report)
             except CoverageException as exc:

--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -11,6 +11,11 @@ import pytest
 from coverage.results import display_covered
 from coverage.results import should_fail_under
 
+try:
+    from pytest import TerminalReporter  # noqa: PT013
+except ImportError:
+    from _pytest.terminal import TerminalReporter
+
 from . import CovDisabledWarning
 from . import CovFailUnderWarning
 from . import CovReportWarning
@@ -333,7 +338,8 @@ class CovPlugin:
             # it for unit tests that don't need it
             from coverage.misc import CoverageException
 
-            self.cov_controller.sep(self.cov_report, '=', 'coverage report')
+            tr = TerminalReporter(session.config, self.cov_report)
+            tr.write_sep('=', 'coverage report')
             try:
                 self.cov_total = self.cov_controller.summary(self.cov_report)
             except CoverageException as exc:

--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -217,7 +217,7 @@ class CovPlugin:
         self._start_path = None
         self._disabled = False
         self.options = options
-        self.wrote_heading = False
+        self._wrote_heading = False
 
         is_dist = getattr(options, 'numprocesses', False) or getattr(options, 'distload', False) or getattr(options, 'dist', 'no') != 'no'
         if getattr(options, 'no_cov', False):
@@ -358,9 +358,9 @@ class CovPlugin:
                 compat_session.testsfailed += 1
 
     def write_heading(self, terminalreporter):
-        if not self.wrote_heading:
+        if not self._wrote_heading:
             terminalreporter.write_sep('=', 'tests coverage')
-            self.wrote_heading = True
+            self._wrote_heading = True
 
     def pytest_terminal_summary(self, terminalreporter):
         if self._disabled:

--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -207,7 +207,7 @@ def test_central(pytester, testdir, prop):
 
     result = testdir.runpytest('-v', f'--cov={script.dirpath()}', '--cov-report=term-missing', script, *prop.args)
 
-    result.stdout.fnmatch_lines(['*- coverage: platform *, python * -*', f'test_central* {prop.result} *', '*10 passed*'])
+    result.stdout.fnmatch_lines(['*_ coverage: platform *, python * _*', f'test_central* {prop.result} *', '*10 passed*'])
     assert result.ret == 0
 
 
@@ -218,7 +218,7 @@ def test_annotate(testdir):
 
     result.stdout.fnmatch_lines(
         [
-            '*- coverage: platform *, python * -*',
+            '*_ coverage: platform *, python * _*',
             'Coverage annotated source written next to source',
             '*10 passed*',
         ]
@@ -233,7 +233,7 @@ def test_annotate_output_dir(testdir):
 
     result.stdout.fnmatch_lines(
         [
-            '*- coverage: platform *, python * -*',
+            '*_ coverage: platform *, python * _*',
             'Coverage annotated source written to dir ' + DEST_DIR,
             '*10 passed*',
         ]
@@ -251,7 +251,7 @@ def test_html(testdir):
 
     result.stdout.fnmatch_lines(
         [
-            '*- coverage: platform *, python * -*',
+            '*_ coverage: platform *, python * _*',
             'Coverage HTML written to dir htmlcov',
             '*10 passed*',
         ]
@@ -269,7 +269,7 @@ def test_html_output_dir(testdir):
 
     result.stdout.fnmatch_lines(
         [
-            '*- coverage: platform *, python * -*',
+            '*_ coverage: platform *, python * _*',
             'Coverage HTML written to dir ' + DEST_DIR,
             '*10 passed*',
         ]
@@ -289,7 +289,7 @@ def test_term_report_does_not_interact_with_html_output(testdir):
 
     result.stdout.fnmatch_lines(
         [
-            '*- coverage: platform *, python * -*',
+            '*_ coverage: platform *, python * _*',
             'Coverage HTML written to dir ' + DEST_DIR,
             '*1 passed*',
         ]
@@ -317,7 +317,7 @@ directory = somewhere
 
     result.stdout.fnmatch_lines(
         [
-            '*- coverage: platform *, python * -*',
+            '*_ coverage: platform *, python * _*',
             'Coverage HTML written to dir somewhere',
             '*10 passed*',
         ]
@@ -335,7 +335,7 @@ def test_xml_output_dir(testdir):
 
     result.stdout.fnmatch_lines(
         [
-            '*- coverage: platform *, python * -*',
+            '*_ coverage: platform *, python * _*',
             'Coverage XML written to file ' + XML_REPORT_NAME,
             '*10 passed*',
         ]
@@ -351,7 +351,7 @@ def test_json_output_dir(testdir):
 
     result.stdout.fnmatch_lines(
         [
-            '*- coverage: platform *, python * -*',
+            '*_ coverage: platform *, python * _*',
             'Coverage JSON written to file ' + JSON_REPORT_NAME,
             '*10 passed*',
         ]
@@ -368,7 +368,7 @@ def test_lcov_output_dir(testdir):
 
     result.stdout.fnmatch_lines(
         [
-            '*- coverage: platform *, python * -*',
+            '*_ coverage: platform *, python * _*',
             'Coverage LCOV written to file ' + LCOV_REPORT_NAME,
             '*10 passed*',
         ]
@@ -490,7 +490,7 @@ def test_central_nonspecific(pytester, testdir, prop):
     testdir.tmpdir.join('.coveragerc').write(prop.fullconf)
     result = testdir.runpytest('-v', '--cov', '--cov-report=term-missing', script, *prop.args)
 
-    result.stdout.fnmatch_lines(['*- coverage: platform *, python * -*', f'test_central_nonspecific* {prop.result} *', '*10 passed*'])
+    result.stdout.fnmatch_lines(['*_ coverage: platform *, python * _*', f'test_central_nonspecific* {prop.result} *', '*10 passed*'])
 
     # multi-module coverage report
     assert any(line.startswith('TOTAL ') for line in result.stdout.lines)
@@ -520,7 +520,7 @@ def test_central_coveragerc(pytester, testdir, prop):
 
     result.stdout.fnmatch_lines(
         [
-            '*- coverage: platform *, python * -*',
+            '*_ coverage: platform *, python * _*',
             f'test_central_coveragerc* {prop.result} *',
             '*10 passed*',
         ]
@@ -557,7 +557,7 @@ parallel = true
 
     result.stdout.fnmatch_lines(
         [
-            '*- coverage: platform *, python * -*',
+            '*_ coverage: platform *, python * _*',
             f'src[\\/]mod* {prop.result} *',
             '*10 passed*',
         ]
@@ -599,7 +599,7 @@ def test_foobar(bad):
 
     result.stdout.fnmatch_lines(
         [
-            '*- coverage: platform *, python * -*',
+            '*_ coverage: platform *, python * _*',
             '*mod* 100%',
             '*1 passed*',
         ]
@@ -636,7 +636,7 @@ parallel = true
 
     result.stdout.fnmatch_lines(
         [
-            '*- coverage: platform *, python * -*',
+            '*_ coverage: platform *, python * _*',
             f'src[\\/]child_script* {CHILD_SCRIPT_RESULT}*',
             f'src[\\/]parent_script* {PARENT_SCRIPT_RESULT}*',
         ]
@@ -661,7 +661,7 @@ show_missing = true
 
     result.stdout.fnmatch_lines(
         [
-            '*- coverage: platform *, python * -*',
+            '*_ coverage: platform *, python * _*',
             'Name * Stmts * Miss * Cover * Missing',
             f'test_show_missing_coveragerc* {prop.result} * 11*',
             '*10 passed*',
@@ -767,7 +767,7 @@ def test_dist_collocated(pytester, testdir, prop):
         *prop.args,
     )
 
-    result.stdout.fnmatch_lines(['*- coverage: platform *, python * -*', f'test_dist_collocated* {prop.result} *', '*10 passed*'])
+    result.stdout.fnmatch_lines(['*_ coverage: platform *, python * _*', f'test_dist_collocated* {prop.result} *', '*10 passed*'])
     assert result.ret == 0
 
 
@@ -802,7 +802,7 @@ source =
         *prop.args,
     )
 
-    result.stdout.fnmatch_lines(['*- coverage: platform *, python * -*', f'test_dist_not_collocated* {prop.result} *', '*10 passed*'])
+    result.stdout.fnmatch_lines(['*_ coverage: platform *, python * _*', f'test_dist_not_collocated* {prop.result} *', '*10 passed*'])
     assert result.ret == 0
 
 
@@ -838,7 +838,7 @@ source =
         *prop.args,
     )
 
-    result.stdout.fnmatch_lines(['*- coverage: platform *, python * -*', f'test_dist_not_collocated* {prop.result} *', '*10 passed*'])
+    result.stdout.fnmatch_lines(['*_ coverage: platform *, python * _*', f'test_dist_not_collocated* {prop.result} *', '*10 passed*'])
     assert result.ret == 0
 
 
@@ -850,7 +850,7 @@ def test_central_subprocess(testdir):
 
     result.stdout.fnmatch_lines(
         [
-            '*- coverage: platform *, python * -*',
+            '*_ coverage: platform *, python * _*',
             f'child_script* {CHILD_SCRIPT_RESULT}*',
             f'parent_script* {PARENT_SCRIPT_RESULT}*',
         ]
@@ -876,7 +876,7 @@ parallel = true
 
     result.stdout.fnmatch_lines(
         [
-            '*- coverage: platform *, python * -*',
+            '*_ coverage: platform *, python * _*',
             f'*child_script* {CHILD_SCRIPT_RESULT}*',
             '*parent_script* 100%*',
         ]
@@ -904,7 +904,7 @@ parallel = true
 
     result.stdout.fnmatch_lines(
         [
-            '*- coverage: platform *, python * -*',
+            '*_ coverage: platform *, python * _*',
             f'*child_script* {CHILD_SCRIPT_RESULT}*',
         ]
     )
@@ -930,7 +930,7 @@ parallel = true
     result = testdir.runpytest('-v', '--cov-config=coveragerc', f'--cov={script.dirpath()}', '--cov-branch', script)
     result.stdout.fnmatch_lines(
         [
-            '*- coverage: platform *, python * -*',
+            '*_ coverage: platform *, python * _*',
             'test_central_subprocess_no_subscript* * 3 * 0 * 100%*',
         ]
     )
@@ -948,7 +948,7 @@ def test_dist_subprocess_collocated(testdir):
 
     result.stdout.fnmatch_lines(
         [
-            '*- coverage: platform *, python * -*',
+            '*_ coverage: platform *, python * _*',
             f'child_script* {CHILD_SCRIPT_RESULT}*',
             f'parent_script* {PARENT_SCRIPT_RESULT}*',
         ]
@@ -988,7 +988,7 @@ source =
 
     result.stdout.fnmatch_lines(
         [
-            '*- coverage: platform *, python * -*',
+            '*_ coverage: platform *, python * _*',
             f'child_script* {CHILD_SCRIPT_RESULT}*',
             f'parent_script* {PARENT_SCRIPT_RESULT}*',
         ]
@@ -1061,7 +1061,7 @@ def test_funcarg(testdir):
 
     result = testdir.runpytest('-v', f'--cov={script.dirpath()}', '--cov-report=term-missing', script)
 
-    result.stdout.fnmatch_lines(['*- coverage: platform *, python * -*', 'test_funcarg* 3 * 100%*', '*1 passed*'])
+    result.stdout.fnmatch_lines(['*_ coverage: platform *, python * _*', 'test_funcarg* 3 * 100%*', '*1 passed*'])
     assert result.ret == 0
 
 
@@ -1111,7 +1111,7 @@ if __name__ == "__main__":
 
     result = testdir.runpytest('-vv', f'--cov={script.dirpath()}', '--cov-report=term-missing', script)
 
-    result.stdout.fnmatch_lines(['*- coverage: platform *, python * -*', 'test_cleanup_on_sigterm* 26-27', '*1 passed*'])
+    result.stdout.fnmatch_lines(['*_ coverage: platform *, python * _*', 'test_cleanup_on_sigterm* 26-27', '*1 passed*'])
     assert result.ret == 0
 
 
@@ -1157,7 +1157,7 @@ if __name__ == "__main__":
 
     result = testdir.runpytest('-vv', f'--cov={script.dirpath()}', '--cov-report=term-missing', script)
 
-    result.stdout.fnmatch_lines(['*- coverage: platform *, python * -*', f'test_cleanup_on_sigterm* {setup[1]}', '*1 passed*'])
+    result.stdout.fnmatch_lines(['*_ coverage: platform *, python * _*', f'test_cleanup_on_sigterm* {setup[1]}', '*1 passed*'])
     assert result.ret == 0
 
 
@@ -1201,7 +1201,7 @@ if __name__ == "__main__":
 
     result = testdir.runpytest('-vv', '--assert=plain', f'--cov={script.dirpath()}', '--cov-report=term-missing', script)
 
-    result.stdout.fnmatch_lines(['*- coverage: platform *, python * -*', f'test_cleanup_on_sigterm* {setup[1]}', '*1 passed*'])
+    result.stdout.fnmatch_lines(['*_ coverage: platform *, python * _*', f'test_cleanup_on_sigterm* {setup[1]}', '*1 passed*'])
     assert result.ret == 0
 
 
@@ -1236,7 +1236,7 @@ if __name__ == "__main__":
 
     result = testdir.runpytest('-vv', '--assert=plain', f'--cov={script.dirpath()}', '--cov-report=term-missing', script)
 
-    result.stdout.fnmatch_lines(['*- coverage: platform *, python * -*', 'test_cleanup_on_sigterm* 88%   19-20', '*1 passed*'])
+    result.stdout.fnmatch_lines(['*_ coverage: platform *, python * _*', 'test_cleanup_on_sigterm* 88%   19-20', '*1 passed*'])
     assert result.ret == 0
 
 
@@ -1273,7 +1273,7 @@ if __name__ == "__main__":
 
     result = testdir.runpytest('-vv', '--assert=plain', f'--cov={script.dirpath()}', '--cov-report=term-missing', script)
 
-    result.stdout.fnmatch_lines(['*- coverage: platform *, python * -*', 'test_cleanup_on_sigterm* 89%   22-23', '*1 passed*'])
+    result.stdout.fnmatch_lines(['*_ coverage: platform *, python * _*', 'test_cleanup_on_sigterm* 89%   22-23', '*1 passed*'])
     assert result.ret == 0
 
 
@@ -1505,7 +1505,7 @@ def test_dist_boxed(testdir):
 
     result = testdir.runpytest('-v', '--assert=plain', f'--cov={script.dirpath()}', '--boxed', script)
 
-    result.stdout.fnmatch_lines(['*- coverage: platform *, python * -*', f'test_dist_boxed* {SCRIPT_SIMPLE_RESULT}*', '*1 passed*'])
+    result.stdout.fnmatch_lines(['*_ coverage: platform *, python * _*', f'test_dist_boxed* {SCRIPT_SIMPLE_RESULT}*', '*1 passed*'])
     assert result.ret == 0
 
 
@@ -1516,7 +1516,7 @@ def test_dist_bare_cov(testdir):
 
     result = testdir.runpytest('-v', '--cov', '-n', '1', script)
 
-    result.stdout.fnmatch_lines(['*- coverage: platform *, python * -*', f'test_dist_bare_cov* {SCRIPT_SIMPLE_RESULT}*', '*1 passed*'])
+    result.stdout.fnmatch_lines(['*_ coverage: platform *, python * _*', f'test_dist_bare_cov* {SCRIPT_SIMPLE_RESULT}*', '*1 passed*'])
     assert result.ret == 0
 
 
@@ -1747,7 +1747,7 @@ def test_append_coverage_subprocess(testdir):
 
     result.stdout.fnmatch_lines(
         [
-            '*- coverage: platform *, python * -*',
+            '*_ coverage: platform *, python * _*',
             f'child_script* {CHILD_SCRIPT_RESULT}*',
             f'parent_script* {PARENT_SCRIPT_RESULT}*',
         ]
@@ -1781,7 +1781,7 @@ def test_double_cov(testdir):
     script = testdir.makepyfile(SCRIPT_SIMPLE)
     result = testdir.runpytest('-v', '--assert=plain', '--cov', f'--cov={script.dirpath()}', script)
 
-    result.stdout.fnmatch_lines(['*- coverage: platform *, python * -*', f'test_double_cov* {SCRIPT_SIMPLE_RESULT}*', '*1 passed*'])
+    result.stdout.fnmatch_lines(['*_ coverage: platform *, python * _*', f'test_double_cov* {SCRIPT_SIMPLE_RESULT}*', '*1 passed*'])
     assert result.ret == 0
 
 
@@ -1789,7 +1789,7 @@ def test_double_cov2(testdir):
     script = testdir.makepyfile(SCRIPT_SIMPLE)
     result = testdir.runpytest('-v', '--assert=plain', '--cov', '--cov', script)
 
-    result.stdout.fnmatch_lines(['*- coverage: platform *, python * -*', f'test_double_cov2* {SCRIPT_SIMPLE_RESULT}*', '*1 passed*'])
+    result.stdout.fnmatch_lines(['*_ coverage: platform *, python * _*', f'test_double_cov2* {SCRIPT_SIMPLE_RESULT}*', '*1 passed*'])
     assert result.ret == 0
 
 
@@ -1804,7 +1804,7 @@ def test_cov_reset_then_set(testdir):
     script = testdir.makepyfile(SCRIPT_SIMPLE)
     result = testdir.runpytest('-v', '--assert=plain', f'--cov={script.dirpath()}', '--cov-reset', f'--cov={script.dirpath()}', script)
 
-    result.stdout.fnmatch_lines(['*- coverage: platform *, python * -*', f'test_cov_reset_then_set* {SCRIPT_SIMPLE_RESULT}*', '*1 passed*'])
+    result.stdout.fnmatch_lines(['*_ coverage: platform *, python * _*', f'test_cov_reset_then_set* {SCRIPT_SIMPLE_RESULT}*', '*1 passed*'])
 
 
 @pytest.mark.skipif('sys.platform == "win32" and platform.python_implementation() == "PyPy"')


### PR DESCRIPTION
This PR improves the formatting of separator lines in coverage reports and enhances the robustness of terminal width handling.

#### Why?
- To conform to the visuals from pytest headings.
- To allow clear separation of this plugin output from the previous section

#### Changes:  
- Add a new section heading for the coverage tests output.
- Make all headings the same width as pytest's headings.
- Change separator character of regular headings from `-` to `_`. 
