### PR TITLE
fix failing tests related to broken links

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -9,7 +9,7 @@ Authors
 * Marc Abramowitz - \http://marc-abramowitz.com
 * Thomas Kluyver - https://github.com/takluyver
 * Guillaume Ayoub - http://www.yabz.fr
-* Federico Ceratto - http://firelet.net
+* Federico Ceratto - \http://firelet.net
 * Josh Kalderimis - \http://blog.cookiestack.com
 * Ionel Cristian Mărieș - https://blog.ionelmc.ro
 * Christian Ledermann - https://github.com/cleder

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,7 +39,7 @@ html_last_updated_fmt = '%b %d, %Y'
 html_split_index = False
 html_short_title = f'{project}-{version}'
 
-linkcheck_anchors_ignore = ['^issuecomment-']
+linkcheck_anchors_ignore_for_url = [r'https?://(www\.)?github\.com/.*']
 
 napoleon_use_ivar = True
 napoleon_use_rtype = False

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,6 +39,8 @@ html_last_updated_fmt = '%b %d, %Y'
 html_split_index = False
 html_short_title = f'{project}-{version}'
 
+linkcheck_anchors_ignore = ['^issuecomment-']
+
 napoleon_use_ivar = True
 napoleon_use_rtype = False
 napoleon_use_param = False

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,7 +39,9 @@ html_last_updated_fmt = '%b %d, %Y'
 html_split_index = False
 html_short_title = f'{project}-{version}'
 
-linkcheck_anchors_ignore_for_url = [r'https?://(www\.)?github\.com/.*']
+linkcheck_anchors_ignore_for_url = [
+    r'^https?://(www\.)?github\.com/.*',
+]
 
 napoleon_use_ivar = True
 napoleon_use_rtype = False


### PR DESCRIPTION
as suggested in #678 

**Edit**:
This PR addresses issues related to the Sphinx link checker and updates outdated links to resolve failing tests.

Changes Made
1. Link Check Configuration:
GitHub has changed the way anchors are injected into web pages, causing the Sphinx link checker to fail. This configuration update allows us to skip anchor checking for GitHub URLs, preventing unnecessary build failures.

2. Updated Links:
The http://firelet.net URL is no longer accessible, causing Sphinx's link checker to generate build errors. Adjusted to conform with others in the file that are escaped with backslashes.
