### PR TITLE
Prevent unimported warnings @ pytest-xdist workers

### DIFF
--- a/src/pytest_cov/engine.py
+++ b/src/pytest_cov/engine.py
@@ -450,6 +450,7 @@ class DistWorker(CovController):
             data_suffix=_data_suffix(f'w{self.nodeid}'),
             config_file=self.cov_config,
         )
+        self.cov._warn_unimported_source = False
         self.cov.start()
         self.set_env()
         super().start()


### PR DESCRIPTION
Ref #693

This fixes https://github.com/pytest-dev/pytest-cov/issues/693#issuecomment-2940497942 for me.
Actually, locally, I can also drop these private attribute assignments from `DistMaster` and it works with just disabling a single warning on the worker.
However, when I tried doing this in the project (and not in site-packages of where I'm hitting the problem), it breaks `tests/test_pytest_cov.py::test_xdist_no_data_collected` so I didn't include those changes.

I was hoping that you @ionelmc could take a look and maybe come up with some explanation of why this is happening.

Coverage is being collected and reported, but at the time `coveragepy` is looking into `sys.modules`, the module isn't there. I think xdist makes it unpredictable whether the coverage object in master or in the worker would hit this code path. It probably makes sense to disable this warning when under xdist for workers too. It's unreliable at best in such a setup.