### PR TITLE
Fix document theme parameter in sphinx config file

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,7 +31,9 @@ extlinks = {
 }
 html_theme = 'furo'
 html_theme_options = {
-    'githuburl': 'https://github.com/pytest-dev/pytest-cov/',
+    'source_repository': 'https://github.com/pytest-dev/pytest-cov/',
+    'source_branch': 'master',
+    'source_directory': 'docs/',
 }
 
 html_use_smartypants = True


### PR DESCRIPTION
Fixed the `html_theme_options` in config file since the option `githuburl` is not supported.
(ref: https://pradyunsg.me/furo/customisation/top-of-page-buttons/#with-popular-vcs-hosts .)
Now the "view/edit" buttons (on the top right) correctly point to the github repository.
