### PR TITLE
Remove some extra indents in documentation

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -10,9 +10,9 @@ Bug reports
 
 When `reporting a bug <https://github.com/pytest-dev/pytest-cov/issues>`_ please include:
 
-    * Your operating system name and version.
-    * Any details about your local setup that might be helpful in troubleshooting.
-    * Detailed steps to reproduce the bug.
+* Your operating system name and version.
+* Any details about your local setup that might be helpful in troubleshooting.
+* Detailed steps to reproduce the bug.
 
 Documentation improvements
 ==========================

--- a/README.rst
+++ b/README.rst
@@ -108,7 +108,7 @@ Would produce a report like::
 Documentation
 =============
 
-    https://pytest-cov.readthedocs.io/en/latest/
+https://pytest-cov.readthedocs.io/en/latest/
 
 
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -62,22 +62,22 @@ Reference
 
 The complete list of command line options is:
 
-  --cov=PATH            Measure coverage for filesystem path. (multi-allowed)
-  --cov-report=type     Type of report to generate: term, term-missing,
-                        annotate, html, xml, json, lcov (multi-allowed). term, term-
-                        missing may be followed by ":skip-covered". annotate,
-                        html, xml, json and lcov may be followed by ":DEST" where DEST
-                        specifies the output location. Use --cov-report= to
-                        not generate any output.
-  --cov-config=path     Config file for coverage. Default: .coveragerc
-  --no-cov-on-fail      Do not report coverage if test run fails. Default:
-                        False
-  --no-cov              Disable coverage report completely (useful for
-                        debuggers). Default: False
-  --cov-reset           Reset cov sources accumulated in options so far.
-                        Mostly useful for scripts and configuration files.
-  --cov-fail-under=MIN  Fail if the total coverage is less than MIN.
-  --cov-append          Do not delete coverage but append to current. Default:
-                        False
-  --cov-branch          Enable branch coverage.
-  --cov-context         Choose the method for setting the dynamic context.
+--cov=PATH            Measure coverage for filesystem path. (multi-allowed)
+--cov-report=type     Type of report to generate: term, term-missing,
+                      annotate, html, xml, json, lcov (multi-allowed). term, term-
+                      missing may be followed by ":skip-covered". annotate,
+                      html, xml, json and lcov may be followed by ":DEST" where DEST
+                      specifies the output location. Use --cov-report= to
+                      not generate any output.
+--cov-config=path     Config file for coverage. Default: .coveragerc
+--no-cov-on-fail      Do not report coverage if test run fails. Default:
+                      False
+--no-cov              Disable coverage report completely (useful for
+                      debuggers). Default: False
+--cov-reset           Reset cov sources accumulated in options so far.
+                      Mostly useful for scripts and configuration files.
+--cov-fail-under=MIN  Fail if the total coverage is less than MIN.
+--cov-append          Do not delete coverage but append to current. Default:
+                      False
+--cov-branch          Enable branch coverage.
+--cov-context         Choose the method for setting the dynamic context.


### PR DESCRIPTION
Incorrect indents cause some texts to be misinterpreted as blockquotes and render incorrectly.