### PR TITLE
Adding Markdown support as a file_choice

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -63,3 +63,4 @@ Authors
 * Christian Clauss - https://github.com/cclauss
 * Dawn James - https://github.com/dawngerpony
 * Tsvika Shapira - https://github.com/tsvikas
+* Marcos Boger - https://github.com/marcosboger

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -64,9 +64,9 @@ The complete list of command line options is:
 
 --cov=PATH            Measure coverage for filesystem path. (multi-allowed)
 --cov-report=type     Type of report to generate: term, term-missing,
-                      annotate, html, xml, json, lcov (multi-allowed). term, term-
+                      annotate, html, xml, json, markdown, markdown-append, lcov (multi-allowed). term, term-
                       missing may be followed by ":skip-covered". annotate,
-                      html, xml, json and lcov may be followed by ":DEST" where DEST
+                      html, xml, json, markdown, markdown-append and lcov may be followed by ":DEST" where DEST
                       specifies the output location. Use --cov-report= to
                       not generate any output.
 --cov-config=path     Config file for coverage. Default: .coveragerc

--- a/docs/reporting.rst
+++ b/docs/reporting.rst
@@ -3,7 +3,7 @@ Reporting
 
 It is possible to generate any combination of the reports for a single test run.
 
-The available reports are terminal (with or without missing line numbers shown), HTML, XML, JSON, LCOV and
+The available reports are terminal (with or without missing line numbers shown), HTML, XML, JSON, MARKDOWN (either in 'write' or 'append' mode to file), LCOV and
 annotated source code.
 
 The terminal report without line numbers (default)::
@@ -49,22 +49,26 @@ The terminal report with skip covered::
 
 You can use ``skip-covered`` with ``term-missing`` as well. e.g. ``--cov-report term-missing:skip-covered``
 
-These four report options output to files without showing anything on the terminal::
+These seven report options output to files without showing anything on the terminal::
 
     pytest --cov-report html
             --cov-report xml
             --cov-report json
+            --cov-report markdown
+            --cov-report markdown-append
             --cov-report lcov
             --cov-report annotate
             --cov=myproj tests/
 
-The output location for each of these reports can be specified. The output location for the XML, JSON and LCOV
+The output location for each of these reports can be specified. The output location for the XML, JSON, MARKDOWN and LCOV
 report is a file. Where as the output location for the HTML and annotated source code reports are
 directories::
 
     pytest --cov-report html:cov_html
             --cov-report xml:cov.xml
             --cov-report json:cov.json
+            --cov-report markdown:cov.md
+            --cov-report markdown-append:cov.md
             --cov-report lcov:cov.info
             --cov-report annotate:cov_annotate
             --cov=myproj tests/

--- a/docs/reporting.rst
+++ b/docs/reporting.rst
@@ -68,7 +68,7 @@ directories::
             --cov-report xml:cov.xml
             --cov-report json:cov.json
             --cov-report markdown:cov.md
-            --cov-report markdown-append:cov.md
+            --cov-report markdown-append:cov-append.md
             --cov-report lcov:cov.info
             --cov-report annotate:cov_annotate
             --cov=myproj tests/

--- a/src/pytest_cov/engine.py
+++ b/src/pytest_cov/engine.py
@@ -255,14 +255,21 @@ class CovController:
                 total = self.cov.json_report(ignore_errors=True, outfile=output)
             stream.write('Coverage JSON written to file %s\n' % (self.cov.config.json_output if output is None else output))
 
-        # Produce markdown report if wanted
+        # Produce Markdown report if wanted.
         if 'markdown' in self.cov_report:
             output = self.cov_report['markdown'] or 'coverage.md'
             with _backup(self.cov, 'config'):
-                # TODO: open either in 'w' mode or 'a' mode depending of flags
                 with Path.open(output, 'w') as output_file:
                     total = self.cov.report(ignore_errors=True, file=output_file, output_format='markdown')
-            stream.write(f'Coverage markdown written to file {output}\n')
+            stream.write(f'Coverage Markdown information written to file {output}\n')
+
+        # Produce Markdown report if wanted, appending to output file
+        if 'markdown-append' in self.cov_report:
+            output = self.cov_report['markdown-append'] or 'coverage-append.md'
+            with _backup(self.cov, 'config'):
+                with Path.open(output, 'a') as output_file:
+                    total = self.cov.report(ignore_errors=True, file=output_file, output_format='markdown')
+            stream.write(f'Coverage Markdown information appended to file {output}\n')
 
         # Produce lcov report if wanted.
         if 'lcov' in self.cov_report:

--- a/src/pytest_cov/engine.py
+++ b/src/pytest_cov/engine.py
@@ -259,7 +259,7 @@ class CovController:
         if 'markdown' in self.cov_report:
             output = self.cov_report['markdown'] or 'coverage.md'
             with _backup(self.cov, 'config'):
-                with Path.open(output, 'w') as output_file:
+                with Path(output).open('w') as output_file:
                     total = self.cov.report(ignore_errors=True, file=output_file, output_format='markdown')
             stream.write(f'Coverage Markdown information written to file {output}\n')
 
@@ -267,7 +267,7 @@ class CovController:
         if 'markdown-append' in self.cov_report:
             output = self.cov_report['markdown-append'] or 'coverage-append.md'
             with _backup(self.cov, 'config'):
-                with Path.open(output, 'a') as output_file:
+                with Path(output).open('a') as output_file:
                     total = self.cov.report(ignore_errors=True, file=output_file, output_format='markdown')
             stream.write(f'Coverage Markdown information appended to file {output}\n')
 

--- a/src/pytest_cov/engine.py
+++ b/src/pytest_cov/engine.py
@@ -255,6 +255,15 @@ class CovController:
                 total = self.cov.json_report(ignore_errors=True, outfile=output)
             stream.write('Coverage JSON written to file %s\n' % (self.cov.config.json_output if output is None else output))
 
+        # Produce markdown report if wanted
+        if 'markdown' in self.cov_report:
+            output = self.cov_report['markdown'] or 'coverage.md'
+            with _backup(self.cov, 'config'):
+                # TODO: open either in 'w' mode or 'a' mode depending of flags
+                with Path.open(output, 'w') as output_file:
+                    total = self.cov.report(ignore_errors=True, file=output_file, output_format='markdown')
+            stream.write(f'Coverage markdown written to file {output}\n')
+
         # Produce lcov report if wanted.
         if 'lcov' in self.cov_report:
             output = self.cov_report['lcov']

--- a/src/pytest_cov/engine.py
+++ b/src/pytest_cov/engine.py
@@ -16,7 +16,6 @@ from typing import Union
 
 import coverage
 from coverage.data import CoverageData
-from coverage.misc import CoverageException
 from coverage.sqldata import filename_suffix
 
 from . import CentralCovContextWarning
@@ -256,18 +255,9 @@ class CovController:
                 total = self.cov.json_report(ignore_errors=True, outfile=output)
             stream.write('Coverage JSON written to file %s\n' % (self.cov.config.json_output if output is None else output))
 
-        # Check that markdown and markdown-append don't point to same file
-        if all(x in self.cov_report for x in ['markdown', 'markdown-append']):
-            markdown_file = self.cov_report['markdown'] or 'coverage.md'
-            markdown_append_file = self.cov_report['markdown-append'] or 'coverage.md'
-            if markdown_file == markdown_append_file:
-                error_message = f"markdown and markdown-append options cannot point to the same file: '{markdown_file}'."
-                error_message += ' Please redirect one of them using :DEST (e.g. --cov-report=markdown:dest_file.md)'
-                raise CoverageException(error_message)
-
         # Produce Markdown report if wanted.
         if 'markdown' in self.cov_report:
-            output = self.cov_report['markdown'] or 'coverage.md'
+            output = self.cov_report['markdown']
             with _backup(self.cov, 'config'):
                 with Path(output).open('w') as output_file:
                     total = self.cov.report(ignore_errors=True, file=output_file, output_format='markdown')
@@ -275,7 +265,7 @@ class CovController:
 
         # Produce Markdown report if wanted, appending to output file
         if 'markdown-append' in self.cov_report:
-            output = self.cov_report['markdown-append'] or 'coverage.md'
+            output = self.cov_report['markdown-append']
             with _backup(self.cov, 'config'):
                 with Path(output).open('a') as output_file:
                     total = self.cov.report(ignore_errors=True, file=output_file, output_format='markdown')

--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -82,6 +82,20 @@ class StoreReport(argparse.Action):
         report_type, file = values
         namespace.cov_report[report_type] = file
 
+        # coverage.py doesn't set a default file for markdown output_format
+        if report_type in ['markdown', 'markdown-append'] and file is None:
+            namespace.cov_report[report_type] = 'coverage.md'
+        if all(x in namespace.cov_report for x in ['markdown', 'markdown-append']):
+            self._validate_markdown_dest_files(namespace.cov_report, parser)
+
+    def _validate_markdown_dest_files(self, cov_report_options, parser):
+        markdown_file = cov_report_options['markdown']
+        markdown_append_file = cov_report_options['markdown-append']
+        if markdown_file == markdown_append_file:
+            error_message = f"markdown and markdown-append options cannot point to the same file: '{markdown_file}'."
+            error_message += ' Please redirect one of them using :DEST (e.g. --cov-report=markdown:dest_file.md)'
+            parser.error(error_message)
+
 
 def pytest_addoption(parser):
     """Add options to control coverage."""

--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -27,7 +27,7 @@ COVERAGE_SQLITE_WARNING_RE = re.compile('unclosed database in <sqlite3.Connectio
 
 
 def validate_report(arg):
-    file_choices = ['annotate', 'html', 'xml', 'json', 'lcov']
+    file_choices = ['annotate', 'html', 'xml', 'json', 'markdown', 'lcov']
     term_choices = ['term', 'term-missing']
     term_modifier_choices = ['skip-covered']
     all_choices = term_choices + file_choices
@@ -112,9 +112,9 @@ def pytest_addoption(parser):
         metavar='TYPE',
         type=validate_report,
         help='Type of report to generate: term, term-missing, '
-        'annotate, html, xml, json, lcov (multi-allowed). '
+        'annotate, html, xml, json, markdown, lcov (multi-allowed). '
         'term, term-missing may be followed by ":skip-covered". '
-        'annotate, html, xml, json and lcov may be followed by ":DEST" '
+        'annotate, html, xml, json, markdown and lcov may be followed by ":DEST" '
         'where DEST specifies the output location. '
         'Use --cov-report= to not generate any output.',
     )

--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -27,7 +27,7 @@ COVERAGE_SQLITE_WARNING_RE = re.compile('unclosed database in <sqlite3.Connectio
 
 
 def validate_report(arg):
-    file_choices = ['annotate', 'html', 'xml', 'json', 'markdown', 'lcov']
+    file_choices = ['annotate', 'html', 'xml', 'json', 'markdown', 'markdown-append', 'lcov']
     term_choices = ['term', 'term-missing']
     term_modifier_choices = ['skip-covered']
     all_choices = term_choices + file_choices
@@ -112,9 +112,9 @@ def pytest_addoption(parser):
         metavar='TYPE',
         type=validate_report,
         help='Type of report to generate: term, term-missing, '
-        'annotate, html, xml, json, markdown, lcov (multi-allowed). '
+        'annotate, html, xml, json, markdown, markdown-append, lcov (multi-allowed). '
         'term, term-missing may be followed by ":skip-covered". '
-        'annotate, html, xml, json, markdown and lcov may be followed by ":DEST" '
+        'annotate, html, xml, json, markdown, markdown-append and lcov may be followed by ":DEST" '
         'where DEST specifies the output location. '
         'Use --cov-report= to not generate any output.',
     )

--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -148,6 +148,8 @@ PARENT_SCRIPT_RESULT = '9 * 100%'
 DEST_DIR = 'cov_dest'
 XML_REPORT_NAME = 'cov.xml'
 JSON_REPORT_NAME = 'cov.json'
+MARKDOWN_REPORT_NAME = 'cov.md'
+MARKDOWN_APPEND_REPORT_NAME = 'cov-append.md'
 LCOV_REPORT_NAME = 'cov.info'
 
 xdist_params = pytest.mark.parametrize(
@@ -357,6 +359,61 @@ def test_json_output_dir(testdir):
         ]
     )
     assert testdir.tmpdir.join(JSON_REPORT_NAME).check()
+    assert result.ret == 0
+
+
+def test_markdown_output_dir(testdir):
+    script = testdir.makepyfile(SCRIPT)
+
+    result = testdir.runpytest('-v', '--cov=%s' % script.dirpath(), '--cov-report=markdown:' + MARKDOWN_REPORT_NAME, script)
+
+    result.stdout.fnmatch_lines(
+        [
+            '*_ coverage: platform *, python * _*',
+            'Coverage Markdown information written to file ' + MARKDOWN_REPORT_NAME,
+            '*10 passed*',
+        ]
+    )
+    assert testdir.tmpdir.join(MARKDOWN_REPORT_NAME).check()
+    assert result.ret == 0
+
+
+def test_markdown_append_output_dir(testdir):
+    script = testdir.makepyfile(SCRIPT)
+
+    result = testdir.runpytest('-v', '--cov=%s' % script.dirpath(), '--cov-report=markdown-append:' + MARKDOWN_APPEND_REPORT_NAME, script)
+
+    result.stdout.fnmatch_lines(
+        [
+            '*_ coverage: platform *, python * _*',
+            'Coverage Markdown information appended to file ' + MARKDOWN_APPEND_REPORT_NAME,
+            '*10 passed*',
+        ]
+    )
+    assert testdir.tmpdir.join(MARKDOWN_APPEND_REPORT_NAME).check()
+    assert result.ret == 0
+
+
+def test_markdown_and_markdown_append_work_together(testdir):
+    script = testdir.makepyfile(SCRIPT)
+
+    result = testdir.runpytest(
+        '-v',
+        '--cov=%s' % script.dirpath(),
+        '--cov-report=markdown:' + MARKDOWN_REPORT_NAME,
+        '--cov-report=markdown-append:' + MARKDOWN_APPEND_REPORT_NAME,
+        script,
+    )
+
+    result.stdout.fnmatch_lines(
+        [
+            '*_ coverage: platform *, python * _*',
+            'Coverage Markdown information written to file ' + MARKDOWN_REPORT_NAME,
+            'Coverage Markdown information appended to file ' + MARKDOWN_APPEND_REPORT_NAME,
+            '*10 passed*',
+        ]
+    )
+    assert testdir.tmpdir.join(MARKDOWN_APPEND_REPORT_NAME).check()
     assert result.ret == 0
 
 

--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -417,7 +417,7 @@ def test_markdown_and_markdown_append_work_together(testdir):
     assert result.ret == 0
 
 
-def test_markdown_and_markdown_append_pointing_to_same_file_throws_warning(testdir):
+def test_markdown_and_markdown_append_pointing_to_same_file_throws_error(testdir):
     script = testdir.makepyfile(SCRIPT)
 
     result = testdir.runpytest(
@@ -428,8 +428,8 @@ def test_markdown_and_markdown_append_pointing_to_same_file_throws_warning(testd
         script,
     )
 
-    result.stdout.fnmatch_lines(['*WARNING: Failed to generate report: *', '*_ coverage: platform *, python * _*'])
-    assert result.ret == 0
+    result.stderr.fnmatch_lines(['* error: markdown and markdown-append options cannot point to the same file*'])
+    assert result.ret == 4
 
 
 @pytest.mark.skipif('coverage.version_info < (6, 3)')

--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -417,6 +417,21 @@ def test_markdown_and_markdown_append_work_together(testdir):
     assert result.ret == 0
 
 
+def test_markdown_and_markdown_append_pointing_to_same_file_throws_warning(testdir):
+    script = testdir.makepyfile(SCRIPT)
+
+    result = testdir.runpytest(
+        '-v',
+        '--cov=%s' % script.dirpath(),
+        '--cov-report=markdown:' + MARKDOWN_REPORT_NAME,
+        '--cov-report=markdown-append:' + MARKDOWN_REPORT_NAME,
+        script,
+    )
+
+    result.stdout.fnmatch_lines(['*WARNING: Failed to generate report: *', '*_ coverage: platform *, python * _*'])
+    assert result.ret == 0
+
+
 @pytest.mark.skipif('coverage.version_info < (6, 3)')
 def test_lcov_output_dir(testdir):
     script = testdir.makepyfile(SCRIPT)


### PR DESCRIPTION
Closes https://github.com/pytest-dev/pytest-cov/issues/688

Option which implements markdown support as a file_choice.

We would diverge a bit from the Coverage.py API, creating our own sort of behavior for the `markdown` option. But might be useful indeed.

Example output:
<img width="1087" height="400" alt="image" src="https://github.com/user-attachments/assets/260eb604-5f02-41fc-9984-9fb3b5c7f9b9" />

File generated:
<img width="1079" height="371" alt="image" src="https://github.com/user-attachments/assets/70d01ee4-95ca-4ab9-9b2e-10827a8ef75b" />


