### PR TITLE
Fix syntax for pytest coverage report command

### DIFF
--- a/docs/reporting.rst
+++ b/docs/reporting.rst
@@ -82,7 +82,7 @@ Example for GitHub Actions with ``markdown-append``:
 
 .. code-block:: bash
 
-    pytest --cov-report=markdown-append:${GITHUB_STEP_SUMMARY}.
+    pytest --cov-report markdown-append:$GITHUB_STEP_SUMMARY
            --cov=myproj tests/
 
 To disable the default ``term`` report provide an empty report:


### PR DESCRIPTION
I had trouble getting the advertised command to work. I have changed the docs with fixed syntax.