### PR TITLE
match coverage 7.10.7 warnings

### DIFF
--- a/tests/test_pytest_cov.py
+++ b/tests/test_pytest_cov.py
@@ -1435,8 +1435,8 @@ def test_filterwarnings_error(testdir):
     result.stdout.fnmatch_lines(['* 1 passed *'])
     result.stderr.fnmatch_lines(
         [
-            '* (module-not-measured)',
-            '* (no-data-collected)',
+            '* (module-not-measured)*',
+            '* (no-data-collected)*',
             '* CovReportWarning: Failed to generate report: No data to report.',
         ]
     )


### PR DESCRIPTION
From coverage 7.10.7 changelog: `Most warnings and a few errors now have links to a page in the docs explaining the specific message.  Closes issue 1921.` This should fix tests.