### PR TITLE
Improve handling of ResourceWarning from sqlite3.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,17 @@
 Changelog
 =========
 
+* Improve handling of ResourceWarning from sqlite3.
+
+  The plugin adds warning filter for sqlite3 ``ResourceWarning`` unclosed database (since 6.2.0).
+  It checks if there is already existing plugin for this message by comparing filter regular expression.
+  When filter is specified on command line the message is escaped and does not match an expected message.
+  A check for an escaped regular expression is added to handle this case.
+
+  With this fix one can suppress ``ResourceWarning`` from sqlite3 from command line::
+
+    pytest -W "ignore:unclosed database in <sqlite3.Connection object at:ResourceWarning" ...
+
 7.0.0 (2025-09-09)
 ------------------
 

--- a/src/pytest_cov/plugin.py
+++ b/src/pytest_cov/plugin.py
@@ -17,7 +17,10 @@ from . import PytestCovWarning
 if TYPE_CHECKING:
     from .engine import CovController
 
+# The message is unescaped if it comes from configuration file, and escaped if
+# it comes from command line option (-W) or PYTHONWARNINGS envvar.
 COVERAGE_SQLITE_WARNING_RE = re.compile('unclosed database in <sqlite3.Connection object at', re.I)
+COVERAGE_SQLITE_WARNING_RE2 = re.compile('unclosed\\ database\\ in\\ <sqlite3\\.Connection\\ object\\ at', re.I)
 
 
 def validate_report(arg):
@@ -325,7 +328,7 @@ class CovPlugin:
 
         # we add default warning configuration to prevent certain warnings to bubble up as errors due to rigid filterwarnings configuration
         for _, message, category, _, _ in warnings.filters:
-            if category is ResourceWarning and message == COVERAGE_SQLITE_WARNING_RE:
+            if category is ResourceWarning and message in (COVERAGE_SQLITE_WARNING_RE, COVERAGE_SQLITE_WARNING_RE2):
                 break
         else:
             warnings.filterwarnings('default', 'unclosed database in <sqlite3.Connection object at', ResourceWarning)


### PR DESCRIPTION
The patch allows suppressing ResourceWarnings from sqlite3 by specifying filter on command line with -W option.

In our project we have multiple packages with separate `pyproject.toml` file (or even without it). Our build system runs `pytest` on each of the packages, the only way for us to suppress `ResourceWarnings` from sqlite3 is to pass the filter on the command line. This unfortunately does not work, as command line filter is escaped before compiled to regex, and escaped regex does not match non-escaped one that pytest-cov tries to match. I am adding an escaped message to the check so that both variants are checked.

And in general, I do not think it was a good idea for pytest-cov to enable one specific `ResourceWarning` warning. People who care about super-clean code just use `default` filter or `ResourceWarning` with empty message. In our case we do use `-Wd`, but we cannot fix sqlite3 warnings as they come from `sqlalchemy` which has no easy way to close all connections in connection pool (but it is safe to garbage-collect them).